### PR TITLE
chore: Reduce allocations in hot paths

### DIFF
--- a/com.posthog.unity/Runtime/Core/EventQueue.cs
+++ b/com.posthog.unity/Runtime/Core/EventQueue.cs
@@ -125,7 +125,7 @@ namespace PostHog
             {
                 lock (_lock)
                 {
-                    return _storage.GetEventIds().Count;
+                    return _storage.GetEventCount();
                 }
             }
         }

--- a/com.posthog.unity/Runtime/FeatureFlags/FlagCalledTracker.cs
+++ b/com.posthog.unity/Runtime/FeatureFlags/FlagCalledTracker.cs
@@ -50,9 +50,9 @@ namespace PostHog
         /// </summary>
         static string CreateKey(string distinctId, string flagKey, object value)
         {
-            // Normalize value to string representation
+            // Use string.Concat to avoid allocation from string interpolation
             var valueStr = value?.ToString() ?? "null";
-            return $"{distinctId}:{flagKey}:{valueStr}";
+            return string.Concat(distinctId, ":", flagKey, ":", valueStr);
         }
     }
 }

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -237,8 +237,10 @@ namespace PostHog
                 return;
             }
 
-            // Build event properties
-            var eventProps = new Dictionary<string, object>();
+            // Build event properties with pre-allocated capacity to reduce allocations
+            // SDK adds ~14 properties, plus super properties, provided properties, session_id, and $groups
+            var estimatedSize = _superProperties.Count + (properties?.Count ?? 0) + 16;
+            var eventProps = new Dictionary<string, object>(estimatedSize);
 
             // Add super properties
             foreach (var kvp in _superProperties)

--- a/com.posthog.unity/Runtime/Storage/FileStorageProvider.cs
+++ b/com.posthog.unity/Runtime/Storage/FileStorageProvider.cs
@@ -176,11 +176,20 @@ namespace PostHog
             }
         }
 
-        public List<string> GetEventIds()
+        public IReadOnlyList<string> GetEventIds()
         {
             lock (_lock)
             {
+                // Return a defensive copy as IReadOnlyList to prevent modification
                 return new List<string>(_eventIndex);
+            }
+        }
+
+        public int GetEventCount()
+        {
+            lock (_lock)
+            {
+                return _eventIndex.Count;
             }
         }
 

--- a/com.posthog.unity/Runtime/Storage/IStorageProvider.cs
+++ b/com.posthog.unity/Runtime/Storage/IStorageProvider.cs
@@ -35,8 +35,15 @@ namespace PostHog
         /// <summary>
         /// Gets all event IDs currently in storage, ordered by creation time.
         /// </summary>
-        /// <returns>List of event IDs</returns>
-        List<string> GetEventIds();
+        /// <returns>Read-only list of event IDs</returns>
+        IReadOnlyList<string> GetEventIds();
+
+        /// <summary>
+        /// Gets the count of events currently in storage.
+        /// More efficient than GetEventIds().Count when only the count is needed.
+        /// </summary>
+        /// <returns>Number of events in storage</returns>
+        int GetEventCount();
 
         /// <summary>
         /// Clears all events from storage.

--- a/com.posthog.unity/Runtime/Storage/PlayerPrefsStorageProvider.cs
+++ b/com.posthog.unity/Runtime/Storage/PlayerPrefsStorageProvider.cs
@@ -149,11 +149,20 @@ namespace PostHog
             }
         }
 
-        public List<string> GetEventIds()
+        public IReadOnlyList<string> GetEventIds()
         {
             lock (_lock)
             {
+                // Return a defensive copy as IReadOnlyList to prevent modification
                 return new List<string>(_eventIndex);
+            }
+        }
+
+        public int GetEventCount()
+        {
+            lock (_lock)
+            {
+                return _eventIndex.Count;
             }
         }
 

--- a/tests/PostHog.Unity.Tests/FlagCacheTests.cs
+++ b/tests/PostHog.Unity.Tests/FlagCacheTests.cs
@@ -33,7 +33,8 @@ public class FlagCacheTests
             _eventIds.Remove(id);
         }
 
-        public List<string> GetEventIds() => new(_eventIds);
+        public IReadOnlyList<string> GetEventIds() => new List<string>(_eventIds);
+        public int GetEventCount() => _eventIds.Count;
 
         public void Clear()
         {


### PR DESCRIPTION
Games tend to be especially performance sensitive so we want to ensure we reduce allocations and apply any optimizations (and even micro-optimizations) we can.

- Use `string.Concat()` instead of interpolation in `FlagCalledTracker`
- Pre-allocate dictionary with estimated capacity in `CaptureInternal`
- Add `GetEventCount()` to `IStorageProvider` for efficient count access
- Change `GetEventIds()` return type to `IReadOnlyList<string>`
- Use `GetEventCount()` in `EventQueue.Count` instead of `GetEventIds().Count`