### PR TITLE
chore: Add compile-time Unity version check

### DIFF
--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -1,3 +1,9 @@
+// PostHog Unity SDK requires Unity 2021.3 or later for C# 9.0 features
+// The check is only enforced when building in Unity (not during unit tests)
+#if UNITY_5_3_OR_NEWER && !UNITY_2021_3_OR_NEWER
+#error "PostHog SDK requires Unity 2021.3 or later"
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;


### PR DESCRIPTION
Add preprocessor directive to enforce Unity 2021.3+ requirement. The check only fires in Unity environments (not during unit tests) by requiring `UNITY_5_3_OR_NEWER` to be defined.