### PR TITLE
refactor: Extract platform detection and SDK info to shared utilities

### DIFF
--- a/com.posthog.unity/Runtime/FeatureFlags/FeatureFlagManager.cs
+++ b/com.posthog.unity/Runtime/FeatureFlags/FeatureFlagManager.cs
@@ -497,11 +497,11 @@ namespace PostHog
             {
                 merged["$app_version"] = Application.version;
                 merged["$app_build"] = Application.buildGUID;
-                merged["$os_name"] = GetOSName();
+                merged["$os_name"] = PlatformInfo.GetOperatingSystem();
                 merged["$os_version"] = SystemInfo.operatingSystem;
-                merged["$device_type"] = GetDeviceType();
-                merged["$lib"] = "posthog-unity";
-                merged["$lib_version"] = "1.0.0"; // TODO: Read from package.json
+                merged["$device_type"] = PlatformInfo.GetDeviceType();
+                merged["$lib"] = SdkInfo.LibraryName;
+                merged["$lib_version"] = SdkInfo.Version;
             }
 
             // Override with custom properties
@@ -511,36 +511,6 @@ namespace PostHog
             }
 
             return merged.Count > 0 ? merged : null;
-        }
-
-        static string GetOSName()
-        {
-#if UNITY_IOS
-            return "iOS";
-#elif UNITY_ANDROID
-            return "Android";
-#elif UNITY_WEBGL
-            return "WebGL";
-#elif UNITY_STANDALONE_WIN
-            return "Windows";
-#elif UNITY_STANDALONE_OSX
-            return "macOS";
-#elif UNITY_STANDALONE_LINUX
-            return "Linux";
-#else
-            return Application.platform.ToString();
-#endif
-        }
-
-        static string GetDeviceType()
-        {
-#if UNITY_IOS || UNITY_ANDROID
-            return "Mobile";
-#elif UNITY_WEBGL
-            return "Web";
-#else
-            return "Desktop";
-#endif
         }
 
         #endregion

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -209,11 +209,11 @@ namespace PostHog
 
         IStorageProvider CreateStorageProvider()
         {
-#if UNITY_WEBGL && !UNITY_EDITOR
+    #if UNITY_WEBGL && !UNITY_EDITOR
             return new PlayerPrefsStorageProvider();
-#else
+    #else
             return new FileStorageProvider();
-#endif
+    #endif
         }
 
         #endregion
@@ -344,13 +344,13 @@ namespace PostHog
 
         void AddSdkProperties(Dictionary<string, object> properties)
         {
-            properties["$lib"] = "posthog-unity";
-            properties["$lib_version"] = GetSdkVersion();
+            properties["$lib"] = SdkInfo.LibraryName;
+            properties["$lib_version"] = SdkInfo.Version;
 
             // Add device/platform properties
-            properties["$os"] = GetOperatingSystem();
+            properties["$os"] = PlatformInfo.GetOperatingSystem();
             properties["$os_version"] = SystemInfo.operatingSystem;
-            properties["$device_type"] = GetDeviceType();
+            properties["$device_type"] = PlatformInfo.GetDeviceType();
             properties["$device_manufacturer"] = SystemInfo.deviceModel;
             properties["$device_model"] = SystemInfo.deviceModel;
             properties["$screen_width"] = UnityEngine.Screen.width;
@@ -970,41 +970,6 @@ namespace PostHog
                 return false;
             }
             return true;
-        }
-
-        static string GetSdkVersion()
-        {
-            return "1.0.0"; // TODO: Read from package.json
-        }
-
-        static string GetOperatingSystem()
-        {
-#if UNITY_IOS
-            return "iOS";
-#elif UNITY_ANDROID
-            return "Android";
-#elif UNITY_WEBGL
-            return "WebGL";
-#elif UNITY_STANDALONE_WIN
-            return "Windows";
-#elif UNITY_STANDALONE_OSX
-            return "macOS";
-#elif UNITY_STANDALONE_LINUX
-            return "Linux";
-#else
-            return Application.platform.ToString();
-#endif
-        }
-
-        static string GetDeviceType()
-        {
-#if UNITY_IOS || UNITY_ANDROID
-            return "Mobile";
-#elif UNITY_WEBGL
-            return "Web";
-#else
-            return "Desktop";
-#endif
         }
 
         #endregion

--- a/com.posthog.unity/Runtime/Utilities/PlatformInfo.cs
+++ b/com.posthog.unity/Runtime/Utilities/PlatformInfo.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+namespace PostHog
+{
+    /// <summary>
+    /// Provides platform detection utilities for PostHog SDK.
+    /// </summary>
+    static class PlatformInfo
+    {
+        /// <summary>
+        /// Gets the operating system name.
+        /// </summary>
+        public static string GetOperatingSystem()
+        {
+#if UNITY_IOS
+            return "iOS";
+#elif UNITY_ANDROID
+            return "Android";
+#elif UNITY_WEBGL
+            return "WebGL";
+#elif UNITY_STANDALONE_WIN
+            return "Windows";
+#elif UNITY_STANDALONE_OSX
+            return "macOS";
+#elif UNITY_STANDALONE_LINUX
+            return "Linux";
+#else
+            return Application.platform.ToString();
+#endif
+        }
+
+        /// <summary>
+        /// Gets the device type category.
+        /// </summary>
+        public static string GetDeviceType()
+        {
+#if UNITY_IOS || UNITY_ANDROID
+            return "Mobile";
+#elif UNITY_WEBGL
+            return "Web";
+#else
+            return "Desktop";
+#endif
+        }
+    }
+}

--- a/com.posthog.unity/Runtime/Utilities/SdkInfo.cs
+++ b/com.posthog.unity/Runtime/Utilities/SdkInfo.cs
@@ -1,0 +1,18 @@
+namespace PostHog
+{
+    /// <summary>
+    /// SDK information constants.
+    /// </summary>
+    static class SdkInfo
+    {
+        /// <summary>
+        /// The current SDK version.
+        /// </summary>
+        public const string Version = "1.0.0";
+
+        /// <summary>
+        /// The SDK library name.
+        /// </summary>
+        public const string LibraryName = "posthog-unity";
+    }
+}


### PR DESCRIPTION
Both `PostHogSDK.cs` and `FeatureFlagManager.cs` had identical copies of:

1. `GetOperatingSystem()` - Platform detection logic using Unity preprocessor directives (`#if UNITY_IOS, #elif UNITY_ANDROID`, etc.)
2. `GetDeviceType()` - Device category logic (Mobile/Web/Desktop)
3. SDK version and library name - Hardcoded `"posthog-unity"` and `"1.0.0"` strings with TODO comments

- Create `PlatformInfo.cs` with `GetOperatingSystem()` and `GetDeviceType()`
- Create `SdkInfo.cs` with Version and LibraryName constants
- Update `PostHogSDK.cs` to use shared utilities
- Update `FeatureFlagManager.cs` to use shared utilities
- Remove duplicated platform detection code from both files