### PR TITLE
fix: Use PlayerPrefsStorageProvider on Nintendo Switch

### DIFF
--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -258,7 +258,7 @@ namespace PostHogUnity
 
         IStorageProvider CreateStorageProvider()
         {
-#if UNITY_WEBGL && !UNITY_EDITOR
+#if (UNITY_WEBGL || UNITY_SWITCH) && !UNITY_EDITOR
             return new PlayerPrefsStorageProvider();
 #else
             return new FileStorageProvider();


### PR DESCRIPTION
## :bulb: Motivation and Context
FileStorageProvider causes disk access errors on Nintendo Switch, preventing the SDK from initializing correctly.

## :green_heart: How did you test it?

Manually

## :pencil: Checklist

  1. Add UNITY_SWITCH to the preprocessor guard in CreateStorageProvider
  2. Fall back to PlayerPrefsStorageProvider on Switch, matching WebGL behavior
