### PR TITLE
fix: remove config=true from flags endpoint

### DIFF
--- a/.changeset/remove-config-true-flags-endpoint.md
+++ b/.changeset/remove-config-true-flags-endpoint.md
@@ -1,0 +1,5 @@
+---
+'com.posthog.unity': patch
+---
+
+Remove `config=true` from the feature flags endpoint.

--- a/com.posthog.unity/Runtime/Core/NetworkClient.cs
+++ b/com.posthog.unity/Runtime/Core/NetworkClient.cs
@@ -136,8 +136,7 @@ namespace PostHogUnity
         )
         {
             var normalizedHost = host.TrimEnd('/');
-            var url =
-                $"{normalizedHost}/flags/?v={FeatureFlagsResponse.CurrentVersion}&config=true";
+            var url = $"{normalizedHost}/flags/?v={FeatureFlagsResponse.CurrentVersion}";
 
             var body = new Dictionary<string, object>
             {


### PR DESCRIPTION
## :bulb: Motivation and Context
The Unity SDK still requested feature flags from `/flags/?v=2&config=true`, even though the extra `config=true` query parameter is no longer needed for flag evaluation.

This aligns the Unity SDK with other PostHog SDKs that have already removed the legacy parameter.

## :green_heart: How did you test it?
Verified the URL construction change in `NetworkClient.CreateFlagsRequest` and confirmed there are no remaining `config=true` references in the repo.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->