### PR TITLE
chore: use engineering@posthog.com in package metadata

### DIFF
--- a/com.posthog.unity/package.json
+++ b/com.posthog.unity/package.json
@@ -17,7 +17,7 @@
     ],
     "author": {
         "name": "PostHog",
-        "email": "hey@posthog.com",
+        "email": "engineering@posthog.com",
         "url": "https://posthog.com"
     },
     "repository": {


### PR DESCRIPTION
## :bulb: Motivation and Context

The Unity package metadata still uses `hey@posthog.com` as the author contact email. This updates the published package metadata to use the shared `engineering@posthog.com` address instead.

## :green_heart: How did you test it?

- Verified `com.posthog.unity/package.json` now uses `engineering@posthog.com`
- Confirmed there are no other non-`engineering@posthog.com` `@posthog.com` addresses in package metadata files in this repo

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR
