### PR TITLE
chore: trigger release workflow from merged PR events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: "Release"
 
 on:
-  push:
+  pull_request:
     branches: [main]
+    types: [closed]
   workflow_dispatch:
 
 permissions:
@@ -17,31 +18,22 @@ jobs:
   check-changesets:
     name: Check for changesets
     runs-on: ubuntu-latest
-    # Run when a push to main comes from a merged PR with the 'release' label, or when manually triggered
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    # Run when a PR into main is merged with the 'release' label, or when manually triggered
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     outputs:
       has-changesets: ${{ steps.check.outputs.has-changesets }}
     steps:
-      - name: Check for release label on merged PR
-        if: github.event_name == 'push'
+      - name: Check release label on merged pull request
+        if: github.event_name == 'pull_request'
         id: check-label
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          # Find the PR associated with this merge commit
-          COMMIT_SHA="${{ github.sha }}"
-          PR_NUMBER=$(gh api "/repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" --jq '.[0].number // empty')
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          echo "Merged PR #${PR_NUMBER} into ${{ github.event.pull_request.base.ref }}"
 
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No PR found for commit ${COMMIT_SHA}. Skipping release."
-            echo "has-release-label=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          LABELS=$(jq -r '[.pull_request.labels[].name] | join(", ")' "$GITHUB_EVENT_PATH")
+          echo "PR labels: ${LABELS:-<none>}"
 
-          echo "Found PR #${PR_NUMBER} for commit ${COMMIT_SHA}"
-
-          # Check if the PR has the 'release' label
-          HAS_LABEL=$(gh api "/repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" --jq '[.[] | select(.name == "release")] | length')
+          HAS_LABEL=$(jq '[.pull_request.labels[] | select(.name == "release")] | length' "$GITHUB_EVENT_PATH")
 
           if [ "$HAS_LABEL" -gt 0 ]; then
             echo "✓ PR #${PR_NUMBER} has the 'release' label"


### PR DESCRIPTION
## :bulb: Motivation and Context

The release workflow currently runs on `push` to `main` and then looks up the merged PR from the merge commit SHA. That lookup can race immediately after merge, which can cause labeled release PRs to be skipped.

This switches the workflow to the merged `pull_request` event so it can read PR labels directly from the event payload.

## :green_heart: How did you test it?

- Reviewed the workflow logic change
- Validated `.github/workflows/release.yml` parses as YAML

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR
