### PR TITLE
chore: remove v prefix from release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,9 +181,9 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/releases \
-            -f tag_name="v$NEW_VERSION" \
+            -f tag_name="$NEW_VERSION" \
             -f target_commitish='main' \
-            -f name="v$NEW_VERSION" \
+            -f name="$NEW_VERSION" \
             -f body="$LAST_CHANGELOG_ENTRY" \
             -F draft=false \
             -F prerelease=false \
@@ -197,7 +197,7 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
           thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-          message: "❌ Failed to release `posthog-unity@v${{ steps.apply-changesets.outputs.new-version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+          message: "❌ Failed to release `posthog-unity@${{ steps.apply-changesets.outputs.new-version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
           emoji_reaction: "x"
 
   notify-rejected:


### PR DESCRIPTION
## :bulb: Motivation and Context
This ports the same release-workflow fix from `posthog-go` to `posthog-unity`. The current workflow creates GitHub releases with a `v` prefix in the tag/name fields, but this repo should use plain semantic versions like `1.2.3`.

## :green_heart: How did you test it?
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml-ok"'`
- `git diff --check`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
