### PR TITLE
feat: Use memory-backed sessions

### DIFF
--- a/.changeset/quiet-pandas-rotate.md
+++ b/.changeset/quiet-pandas-rotate.md
@@ -1,0 +1,5 @@
+---
+'com.posthog.unity': minor
+---
+
+Align Unity session handling with other client-side SDKs by using memory-only sessions.

--- a/com.posthog.unity/Runtime/Core/SessionManager.cs
+++ b/com.posthog.unity/Runtime/Core/SessionManager.cs
@@ -1,19 +1,19 @@
 using System;
-using System.Collections.Generic;
 
 namespace PostHogUnity
 {
     /// <summary>
-    /// Manages session tracking with 30-minute inactivity timeout.
+    /// Manages in-memory session tracking with a 30-minute inactivity timeout.
     /// </summary>
     class SessionManager
     {
-        const string SessionStateKey = "session";
+        const string ExpiredWhileBackgroundedReason =
+            "Cleared expired session while app was backgrounded";
         static readonly TimeSpan SessionTimeout = TimeSpan.FromMinutes(30);
         static readonly TimeSpan MaxSessionLength = TimeSpan.FromHours(24);
 
-        readonly IStorageProvider _storage;
         readonly object _lock = new();
+        readonly Func<DateTime> _nowProvider;
 
         string _sessionId;
         DateTime _sessionStartTime;
@@ -26,38 +26,25 @@ namespace PostHogUnity
             {
                 lock (_lock)
                 {
-                    EnsureSession();
-                    return _sessionId;
+                    return GetSessionIdInternal(_nowProvider());
                 }
             }
         }
 
-        public SessionManager(IStorageProvider storage)
+        public SessionManager(Func<DateTime> nowProvider = null)
         {
-            _storage = storage;
+            _nowProvider = nowProvider ?? (() => DateTime.UtcNow);
             _isInForeground = true;
-            LoadState();
         }
 
         /// <summary>
-        /// Updates the last activity time, potentially rotating the session.
+        /// Updates the last activity time, potentially rotating or clearing the session.
         /// </summary>
         public void Touch()
         {
             lock (_lock)
             {
-                var now = DateTime.UtcNow;
-
-                // Check if we need a new session
-                if (ShouldRotateSession(now))
-                {
-                    StartNewSession();
-                }
-                else
-                {
-                    _lastActivityTime = now;
-                    SaveState();
-                }
+                TouchInternal(_nowProvider());
             }
         }
 
@@ -68,13 +55,7 @@ namespace PostHogUnity
         {
             lock (_lock)
             {
-                var now = DateTime.UtcNow;
-                _sessionId = UuidV7.Generate();
-                _sessionStartTime = now;
-                _lastActivityTime = now;
-                SaveState();
-
-                PostHogLogger.Debug($"Started new session: {_sessionId}");
+                StartNewSessionInternal(_nowProvider());
             }
         }
 
@@ -86,17 +67,20 @@ namespace PostHogUnity
             lock (_lock)
             {
                 _isInForeground = true;
-                var now = DateTime.UtcNow;
+                var now = _nowProvider();
 
-                if (ShouldRotateSession(now))
+                if (string.IsNullOrEmpty(_sessionId))
                 {
-                    StartNewSession();
+                    StartNewSessionInternal(now);
+                    return;
                 }
-                else
+
+                if (HandleExpiredSession(now))
                 {
-                    _lastActivityTime = now;
-                    SaveState();
+                    return;
                 }
+
+                _lastActivityTime = now;
             }
         }
 
@@ -108,8 +92,11 @@ namespace PostHogUnity
             lock (_lock)
             {
                 _isInForeground = false;
-                _lastActivityTime = DateTime.UtcNow;
-                SaveState();
+
+                if (!string.IsNullOrEmpty(_sessionId))
+                {
+                    _lastActivityTime = _nowProvider();
+                }
             }
         }
 
@@ -120,109 +107,104 @@ namespace PostHogUnity
         {
             lock (_lock)
             {
-                _sessionId = null;
-                SaveState();
-                PostHogLogger.Debug("Session ended");
+                ClearSessionInternal("Session ended");
             }
         }
 
-        void EnsureSession()
+        string GetSessionIdInternal(DateTime now)
         {
-            if (string.IsNullOrEmpty(_sessionId) && _isInForeground)
-            {
-                StartNewSession();
-            }
-        }
-
-        bool ShouldRotateSession(DateTime now)
-        {
-            // No session exists
             if (string.IsNullOrEmpty(_sessionId))
             {
-                return true;
+                if (_isInForeground)
+                {
+                    return StartNewSessionInternal(now);
+                }
+
+                return null;
             }
 
-            // Session exceeded max length (24 hours)
+            HandleExpiredSession(now);
+            return _sessionId;
+        }
+
+        void TouchInternal(DateTime now)
+        {
+            if (string.IsNullOrEmpty(_sessionId))
+            {
+                return;
+            }
+
+            if (HandleExpiredSession(now))
+            {
+                return;
+            }
+
+            _lastActivityTime = now;
+        }
+
+        bool HandleExpiredSession(DateTime now)
+        {
+            if (!HasExpiredSession(now))
+            {
+                return false;
+            }
+
+            if (_isInForeground)
+            {
+                StartNewSessionInternal(now);
+            }
+            else
+            {
+                ClearSessionInternal(ExpiredWhileBackgroundedReason);
+            }
+
+            return true;
+        }
+
+        bool HasExpiredSession(DateTime now)
+        {
+            if (string.IsNullOrEmpty(_sessionId))
+            {
+                return false;
+            }
+
             if (now - _sessionStartTime > MaxSessionLength)
             {
-                PostHogLogger.Debug("Session exceeded max length, rotating");
+                PostHogLogger.Debug("Session exceeded max length");
                 return true;
             }
 
-            // Session timed out (30 minutes of inactivity)
             if (now - _lastActivityTime > SessionTimeout)
             {
-                PostHogLogger.Debug("Session timed out, rotating");
+                PostHogLogger.Debug("Session timed out");
                 return true;
             }
 
             return false;
         }
 
-        void LoadState()
+        string StartNewSessionInternal(DateTime now)
         {
-            try
-            {
-                var json = _storage.LoadState(SessionStateKey);
-                if (!string.IsNullOrEmpty(json))
-                {
-                    var state = JsonSerializer.DeserializeDictionary(json);
-                    if (state != null)
-                    {
-                        _sessionId = state.TryGetValue("sessionId", out var sid)
-                            ? sid?.ToString()
-                            : null;
+            _sessionId = UuidV7.Generate();
+            _sessionStartTime = now;
+            _lastActivityTime = now;
 
-                        if (
-                            state.TryGetValue("sessionStartTime", out var startTime)
-                            && startTime != null
-                        )
-                        {
-                            if (DateTime.TryParse(startTime.ToString(), out var parsed))
-                            {
-                                _sessionStartTime = parsed;
-                            }
-                        }
-
-                        if (
-                            state.TryGetValue("lastActivityTime", out var activityTime)
-                            && activityTime != null
-                        )
-                        {
-                            if (DateTime.TryParse(activityTime.ToString(), out var parsed))
-                            {
-                                _lastActivityTime = parsed;
-                            }
-                        }
-
-                        PostHogLogger.Debug($"Loaded session: {_sessionId}");
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                PostHogLogger.Error("Failed to load session state", ex);
-            }
+            PostHogLogger.Debug($"Started new session: {_sessionId}");
+            return _sessionId;
         }
 
-        void SaveState()
+        void ClearSessionInternal(string reason)
         {
-            try
+            if (string.IsNullOrEmpty(_sessionId))
             {
-                var state = new Dictionary<string, object>
-                {
-                    ["sessionId"] = _sessionId,
-                    ["sessionStartTime"] = _sessionStartTime.ToString("o"),
-                    ["lastActivityTime"] = _lastActivityTime.ToString("o"),
-                };
+                return;
+            }
 
-                var json = JsonSerializer.Serialize(state);
-                _storage.SaveState(SessionStateKey, json);
-            }
-            catch (Exception ex)
-            {
-                PostHogLogger.Error("Failed to save session state", ex);
-            }
+            _sessionId = null;
+            _sessionStartTime = default;
+            _lastActivityTime = default;
+
+            PostHogLogger.Debug(reason);
         }
     }
 }

--- a/com.posthog.unity/Runtime/Core/SessionManager.cs
+++ b/com.posthog.unity/Runtime/Core/SessionManager.cs
@@ -111,6 +111,8 @@ namespace PostHogUnity
             }
         }
 
+        // Must only be called while holding _lock. HandleExpiredSession mutates _sessionId
+        // before we return it, so callers need the same lock around the full operation.
         string GetSessionIdInternal(DateTime now)
         {
             if (string.IsNullOrEmpty(_sessionId))

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -132,7 +132,7 @@ namespace PostHogUnity
             // Initialize components
             _networkClient = new NetworkClient(config);
             _identityManager = new IdentityManager(config, _storage);
-            _sessionManager = new SessionManager(_storage);
+            _sessionManager = new SessionManager();
             _eventQueue = new EventQueue(config, _storage, _networkClient);
 
             // Initialize feature flag manager

--- a/tests/PostHog.Unity.Tests/SessionManagerTests.cs
+++ b/tests/PostHog.Unity.Tests/SessionManagerTests.cs
@@ -4,8 +4,13 @@ namespace PostHogUnity.Tests
 {
     public class SessionManagerTests
     {
-        [Fact]
-        public void SessionId_RotatesOnlyAfterInactivityTimeoutBoundary()
+        [Theory]
+        [InlineData(30, false)]
+        [InlineData(24 * 60, true)]
+        public void SessionId_RotatesOnlyAfterTimeoutBoundary(
+            int boundaryMinutes,
+            bool keepSessionActiveUntilBoundary
+        )
         {
             var start = new DateTime(2026, 4, 2, 14, 57, 39, DateTimeKind.Utc);
             var now = start;
@@ -13,10 +18,21 @@ namespace PostHogUnity.Tests
 
             var originalSessionId = sessionManager.SessionId;
 
-            now = start.AddMinutes(30);
+            if (keepSessionActiveUntilBoundary)
+            {
+                // Keep the session active until just before the max session length.
+                for (int i = 0; i < 49; i++)
+                {
+                    now = now.AddMinutes(29);
+                    sessionManager.Touch();
+                }
+            }
+
+            var boundary = start.AddMinutes(boundaryMinutes);
+            now = boundary;
             Assert.Equal(originalSessionId, sessionManager.SessionId);
 
-            now = start.AddMinutes(30).AddTicks(1);
+            now = boundary.AddTicks(1);
             var rotatedSessionId = sessionManager.SessionId;
 
             Assert.NotNull(originalSessionId);
@@ -75,33 +91,6 @@ namespace PostHogUnity.Tests
             Assert.NotNull(originalSessionId);
             Assert.NotNull(restartedSessionId);
             Assert.NotEqual(originalSessionId, restartedSessionId);
-        }
-
-        [Fact]
-        public void SessionId_RotatesOnlyAfterMaxSessionLengthBoundary()
-        {
-            var start = new DateTime(2026, 4, 2, 14, 57, 39, DateTimeKind.Utc);
-            var now = start;
-            var sessionManager = new SessionManager(() => now);
-
-            var originalSessionId = sessionManager.SessionId;
-
-            // Keep the session active until just before the max session length.
-            for (int i = 0; i < 49; i++)
-            {
-                now = now.AddMinutes(29);
-                sessionManager.Touch();
-            }
-
-            now = start.AddHours(24);
-            Assert.Equal(originalSessionId, sessionManager.SessionId);
-
-            now = start.AddHours(24).AddTicks(1);
-            var rotatedSessionId = sessionManager.SessionId;
-
-            Assert.NotNull(originalSessionId);
-            Assert.NotNull(rotatedSessionId);
-            Assert.NotEqual(originalSessionId, rotatedSessionId);
         }
     }
 }

--- a/tests/PostHog.Unity.Tests/SessionManagerTests.cs
+++ b/tests/PostHog.Unity.Tests/SessionManagerTests.cs
@@ -1,0 +1,107 @@
+using PostHogUnity;
+
+namespace PostHogUnity.Tests
+{
+    public class SessionManagerTests
+    {
+        [Fact]
+        public void SessionId_RotatesOnlyAfterInactivityTimeoutBoundary()
+        {
+            var start = new DateTime(2026, 4, 2, 14, 57, 39, DateTimeKind.Utc);
+            var now = start;
+            var sessionManager = new SessionManager(() => now);
+
+            var originalSessionId = sessionManager.SessionId;
+
+            now = start.AddMinutes(30);
+            Assert.Equal(originalSessionId, sessionManager.SessionId);
+
+            now = start.AddMinutes(30).AddTicks(1);
+            var rotatedSessionId = sessionManager.SessionId;
+
+            Assert.NotNull(originalSessionId);
+            Assert.NotNull(rotatedSessionId);
+            Assert.NotEqual(originalSessionId, rotatedSessionId);
+        }
+
+        [Fact]
+        public void SessionId_IsClearedOnlyAfterBackgroundInactivityTimeoutBoundary()
+        {
+            var start = new DateTime(2026, 4, 2, 14, 57, 39, DateTimeKind.Utc);
+            var now = start;
+            var sessionManager = new SessionManager(() => now);
+
+            var originalSessionId = sessionManager.SessionId;
+            sessionManager.OnBackground();
+
+            now = start.AddMinutes(30);
+            Assert.Equal(originalSessionId, sessionManager.SessionId);
+
+            now = start.AddMinutes(30).AddTicks(1);
+
+            Assert.NotNull(originalSessionId);
+            Assert.Null(sessionManager.SessionId);
+        }
+
+        [Fact]
+        public void OnForeground_StartsNewSessionAfterBackgroundTimeout()
+        {
+            var now = new DateTime(2026, 4, 2, 14, 57, 39, DateTimeKind.Utc);
+            var sessionManager = new SessionManager(() => now);
+
+            var originalSessionId = sessionManager.SessionId;
+            sessionManager.OnBackground();
+            now = now.AddMinutes(31);
+            sessionManager.OnForeground();
+
+            var newSessionId = sessionManager.SessionId;
+
+            Assert.NotNull(originalSessionId);
+            Assert.NotNull(newSessionId);
+            Assert.NotEqual(originalSessionId, newSessionId);
+        }
+
+        [Fact]
+        public void NewSessionManagerInstanceStartsNewSessionWithinInactivityTimeout()
+        {
+            var now = new DateTime(2026, 4, 2, 14, 57, 39, DateTimeKind.Utc);
+            var firstSessionManager = new SessionManager(() => now);
+            var originalSessionId = firstSessionManager.SessionId;
+
+            now = now.AddMinutes(1);
+            var restartedSessionManager = new SessionManager(() => now);
+            var restartedSessionId = restartedSessionManager.SessionId;
+
+            Assert.NotNull(originalSessionId);
+            Assert.NotNull(restartedSessionId);
+            Assert.NotEqual(originalSessionId, restartedSessionId);
+        }
+
+        [Fact]
+        public void SessionId_RotatesOnlyAfterMaxSessionLengthBoundary()
+        {
+            var start = new DateTime(2026, 4, 2, 14, 57, 39, DateTimeKind.Utc);
+            var now = start;
+            var sessionManager = new SessionManager(() => now);
+
+            var originalSessionId = sessionManager.SessionId;
+
+            // Keep the session active until just before the max session length.
+            for (int i = 0; i < 49; i++)
+            {
+                now = now.AddMinutes(29);
+                sessionManager.Touch();
+            }
+
+            now = start.AddHours(24);
+            Assert.Equal(originalSessionId, sessionManager.SessionId);
+
+            now = start.AddHours(24).AddTicks(1);
+            var rotatedSessionId = sessionManager.SessionId;
+
+            Assert.NotNull(originalSessionId);
+            Assert.NotNull(rotatedSessionId);
+            Assert.NotEqual(originalSessionId, rotatedSessionId);
+        }
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Unity sessions were persisted to disk, which could allow a stale session ID to be reused after a cold app relaunch. Other client-side/mobile SDKs treat sessions as in-memory lifecycle state, so a cold app relaunch starts a fresh session while in-process foreground/background behavior still follows timeout rules.

This aligns Unity session handling with the other client-side SDKs and prevents stale persisted session IDs from bridging separate app launches.

Fixes #59.

## :green_heart: How did you test it?

- Added unit tests for inactivity timeout boundaries, background timeout behavior, max session length, and new manager instances starting fresh sessions.
- Ran `dotnet test tests/PostHog.Unity.Tests/PostHog.Unity.Tests.csproj`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR
