### PR TITLE
fix: no-op SDK setup without API key

### DIFF
--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -72,7 +72,14 @@ namespace PostHogUnity
         {
             if (config == null)
             {
-                throw new ArgumentNullException(nameof(config));
+                PostHogLogger.Warning("PostHog SDK setup skipped: configuration is null.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(config.ApiKey))
+            {
+                PostHogLogger.Warning("PostHog SDK setup skipped: API key is not configured.");
+                return;
             }
 
             config.Validate();

--- a/com.posthog.unity/Runtime/Utilities/PostHogLogger.cs
+++ b/com.posthog.unity/Runtime/Utilities/PostHogLogger.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace PostHogUnity
@@ -18,7 +19,7 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Debug)
             {
-                UnityEngine.Debug.Log($"[PostHog] {message}");
+                LogSafely(() => UnityEngine.Debug.Log($"[PostHog] {message}"));
             }
         }
 
@@ -26,7 +27,7 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Info)
             {
-                UnityEngine.Debug.Log($"[PostHog] {message}");
+                LogSafely(() => UnityEngine.Debug.Log($"[PostHog] {message}"));
             }
         }
 
@@ -34,7 +35,7 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Warning)
             {
-                UnityEngine.Debug.LogWarning($"[PostHog] {message}");
+                LogSafely(() => UnityEngine.Debug.LogWarning($"[PostHog] {message}"));
             }
         }
 
@@ -42,7 +43,7 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Error)
             {
-                UnityEngine.Debug.LogError($"[PostHog] {message}");
+                LogSafely(() => UnityEngine.Debug.LogError($"[PostHog] {message}"));
             }
         }
 
@@ -50,7 +51,19 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Error)
             {
-                UnityEngine.Debug.LogError($"[PostHog] {message}: {ex}");
+                LogSafely(() => UnityEngine.Debug.LogError($"[PostHog] {message}: {ex}"));
+            }
+        }
+
+        static void LogSafely(Action log)
+        {
+            try
+            {
+                log();
+            }
+            catch
+            {
+                // Logging should never crash the SDK when Unity logging is unavailable.
             }
         }
     }

--- a/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
@@ -1,0 +1,47 @@
+using PostHogUnity;
+
+namespace PostHogUnity.Tests
+{
+    public class PostHogSDKTests
+    {
+        public class TheSetupMethod
+        {
+            [Fact]
+            public void WithNullConfig_DoesNotThrowAndDoesNotInitialize()
+            {
+                var exception = Record.Exception(() => PostHogSDK.Setup(null));
+
+                Assert.Null(exception);
+                Assert.False(PostHogSDK.IsInitialized);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("   ")]
+            public void WithMissingApiKey_DoesNotThrowAndDoesNotInitialize(string apiKey)
+            {
+                var config = new PostHogConfig { ApiKey = apiKey };
+
+                var exception = Record.Exception(() => PostHogSDK.Setup(config));
+
+                Assert.Null(exception);
+                Assert.False(PostHogSDK.IsInitialized);
+            }
+        }
+
+        public class ThePostHogSetupMethod
+        {
+            [Fact]
+            public void WithMissingApiKey_DoesNotThrowAndDoesNotInitialize()
+            {
+                var config = new PostHogConfig { ApiKey = "\t" };
+
+                var exception = Record.Exception(() => PostHog.Setup(config));
+
+                Assert.Null(exception);
+                Assert.False(PostHog.IsInitialized);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary\n- make manual PostHogSDK.Setup/PostHog.Setup return without initializing when config is null or API key is null, empty, or whitespace\n- keep PostHogConfig.Validate API key validation and auto-init API key skip behavior intact\n- add focused setup tests for missing config/API key\n\n## Tests\n- DOTNET_ROLL_FORWARD=Major bin/test\n- DOTNET_ROLL_FORWARD=Major bin/fmt --check\n\nNote: local plain bin/test requires .NET 9 runtime; this machine only has .NET 10, so tests were run with DOTNET_ROLL_FORWARD=Major.