### PR TITLE
fix: default host when empty

### DIFF
--- a/.changeset/default-empty-host.md
+++ b/.changeset/default-empty-host.md
@@ -1,0 +1,5 @@
+---
+"com.posthog.unity": patch
+---
+
+Default the PostHog host when configured as null or empty.

--- a/com.posthog.unity/Runtime/PostHogConfig.cs
+++ b/com.posthog.unity/Runtime/PostHogConfig.cs
@@ -14,11 +14,13 @@ namespace PostHogUnity
         /// </summary>
         public string ApiKey { get; set; }
 
+        const string DefaultHost = "https://us.i.posthog.com";
+
         /// <summary>
         /// The PostHog instance URL.
         /// Defaults to the US cloud instance.
         /// </summary>
-        public string Host { get; set; } = "https://us.i.posthog.com";
+        public string Host { get; set; } = DefaultHost;
 
         /// <summary>
         /// Number of events to queue before triggering a flush.
@@ -176,7 +178,7 @@ namespace PostHogUnity
 
             if (string.IsNullOrWhiteSpace(Host))
             {
-                throw new ArgumentException("Host is required", nameof(Host));
+                Host = DefaultHost;
             }
 
             if (FlushAt < 1)

--- a/tests/PostHog.Unity.Tests/PostHogConfigTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogConfigTests.cs
@@ -64,21 +64,23 @@ namespace PostHogUnity.Tests
             }
 
             [Fact]
-            public void WithNullHost_ThrowsArgumentException()
+            public void WithNullHost_DefaultsHost()
             {
                 var config = new PostHogConfig { ApiKey = "phc_test_key", Host = null };
 
-                var ex = Assert.Throws<ArgumentException>(() => config.Validate());
-                Assert.Equal("Host", ex.ParamName);
+                config.Validate();
+
+                Assert.Equal("https://us.i.posthog.com", config.Host);
             }
 
             [Fact]
-            public void WithEmptyHost_ThrowsArgumentException()
+            public void WithEmptyHost_DefaultsHost()
             {
                 var config = new PostHogConfig { ApiKey = "phc_test_key", Host = "" };
 
-                var ex = Assert.Throws<ArgumentException>(() => config.Validate());
-                Assert.Equal("Host", ex.ParamName);
+                config.Validate();
+
+                Assert.Equal("https://us.i.posthog.com", config.Host);
             }
 
             [Fact]

--- a/tests/PostHog.Unity.Tests/PostHogConfigTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogConfigTests.cs
@@ -63,20 +63,13 @@ namespace PostHogUnity.Tests
                 Assert.Equal("ApiKey", ex.ParamName);
             }
 
-            [Fact]
-            public void WithNullHost_DefaultsHost()
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("   ")]
+            public void WithNullEmptyOrWhitespaceHost_DefaultsHost(string host)
             {
-                var config = new PostHogConfig { ApiKey = "phc_test_key", Host = null };
-
-                config.Validate();
-
-                Assert.Equal("https://us.i.posthog.com", config.Host);
-            }
-
-            [Fact]
-            public void WithEmptyHost_DefaultsHost()
-            {
-                var config = new PostHogConfig { ApiKey = "phc_test_key", Host = "" };
+                var config = new PostHogConfig { ApiKey = "phc_test_key", Host = host };
 
                 config.Validate();
 


### PR DESCRIPTION
## :bulb: Motivation and Context

`PostHogConfig` already defaults `Host` when omitted, but explicitly setting it to `null` or an empty value caused validation to fail. This keeps host configuration optional by falling back to the default PostHog host for blank values.

## :green_heart: How did you test it?

- [x] `DOTNET_ROLL_FORWARD=Major dotnet test tests/PostHog.Unity.Tests/PostHog.Unity.Tests.csproj --no-restore`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR
