### PR TITLE
chore: trigger releases from main changesets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,5 @@
 ### If releasing new changes
 
 - [ ] Ran `pnpm changeset` to generate a changeset file
-- [ ] Added the `release` label to the PR
 
 <!-- For more details check RELEASING.md -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: "Release"
 
 on:
-  pull_request:
+  push:
     branches: [main]
-    types: [closed]
+    paths:
+      - '.changeset/**'
   workflow_dispatch:
 
 permissions:
@@ -18,33 +19,11 @@ jobs:
   check-changesets:
     name: Check for changesets
     runs-on: ubuntu-latest
-    # Run when a PR into main is merged with the 'release' label, or when manually triggered
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     outputs:
       has-changesets: ${{ steps.check.outputs.has-changesets }}
     steps:
-      - name: Check release label on merged pull request
-        if: github.event_name == 'pull_request'
-        id: check-label
-        run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          echo "Merged PR #${PR_NUMBER} into ${{ github.event.pull_request.base.ref }}"
-
-          LABELS=$(jq -r '[.pull_request.labels[].name] | join(", ")' "$GITHUB_EVENT_PATH")
-          echo "PR labels: ${LABELS:-<none>}"
-
-          HAS_LABEL=$(jq '[.pull_request.labels[] | select(.name == "release")] | length' "$GITHUB_EVENT_PATH")
-
-          if [ "$HAS_LABEL" -gt 0 ]; then
-            echo "✓ PR #${PR_NUMBER} has the 'release' label"
-            echo "has-release-label=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "PR #${PR_NUMBER} does not have the 'release' label. Skipping release."
-            echo "has-release-label=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Checkout repository
-        if: github.event_name == 'workflow_dispatch' || steps.check-label.outputs.has-release-label == 'true'
         uses: actions/checkout@v6
         with:
           ref: main
@@ -52,7 +31,6 @@ jobs:
 
       - name: Check for changesets
         id: check
-        if: github.event_name == 'workflow_dispatch' || steps.check-label.outputs.has-release-label == 'true'
         run: |
           if [ ! -d ".changeset" ] || [ -z "$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md)" ]; then
             echo "❌ No changesets found. Cannot proceed with release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - '.changeset/**'
+      - '.changeset/*.md'
   workflow_dispatch:
 
 permissions:
@@ -132,7 +132,7 @@ jobs:
             echo "No changes to commit"
             echo "committed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: release $NEW_VERSION [version bump]"
+            git commit -m "chore: release $NEW_VERSION [version bump] [skip ci]"
             git push origin main
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,98 +1,45 @@
 # Releasing
 
-This document describes how to release a new version of the PostHog Unity SDK.
+This repository uses [Changesets](https://github.com/changesets/changesets) for version management and an automated GitHub Actions workflow for releases.
 
-## Overview
+## How to Release
 
-Releases use [changesets](https://github.com/changesets/changesets) for version management and changelog generation:
+### 1. Add a Changeset
 
-1. Add a changeset to your PR describing the change
-2. Add the `release` label to the PR
-3. Merge the PR — GitHub Actions handles the rest
-
-## Prerequisites
-
-- [Node.js](https://nodejs.org/) (see `.nvmrc` for version)
-- [pnpm](https://pnpm.io/) installed (`npm install -g pnpm`)
-
-Run `pnpm install` to install dependencies.
-
-## Adding a Changeset
-
-When you make a change that should be included in the next release, add a changeset:
+When making a change that should be released, add a changeset:
 
 ```bash
 pnpm changeset
 ```
 
-This will prompt you to:
+This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
 
-1. Select the package(s) affected (`com.posthog.unity`)
-2. Choose the semver bump type (patch/minor/major)
-3. Write a summary of the change
+### 2. Merge the Pull Request
 
-The changeset file is created in `.changeset/` and should be committed with your PR.
+After review, merge the PR to `main`. No GitHub release label is required.
 
-### Version Guidelines
-
-Follow [Semantic Versioning](https://semver.org/):
-
-- **patch**: Bug fixes, backwards compatible
-- **minor**: New features, backwards compatible
-- **major**: Breaking changes
-
-## Release Process
-
-### 1. Create your PR with a changeset
-
-Include a changeset file in your PR (created via `pnpm changeset`).
-
-### 2. Add the `release` label
-
-Add the `release` label to the PR before or after merging.
-
-### 3. Merge the PR
-
-When a PR with the `release` label is merged to `main`, the release workflow:
+A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
 
 1. Checks for pending changesets
-2. Sends a Slack notification requesting approval
-3. On approval:
-   - Applies changesets (bumps version, updates CHANGELOG.md)
-   - Syncs version to `com.posthog.unity/package.json` and `SdkInfo.Generated.cs`
-   - Commits the version bump to `main`
-   - Creates a git tag (`vX.Y.Z`)
-   - Creates a GitHub Release with auto-generated notes
+2. Notifies the client libraries team in Slack for approval
+3. Waits for approval from a maintainer via the GitHub `Release` environment
+4. The workflow applies Changesets, syncs Unity package versions, tags the release, and creates a GitHub Release.
+5. Notifies Slack when the release completes or fails
 
-### Manual trigger
+### Manual Trigger
 
-You can also trigger the release workflow manually from the [Actions tab](../../actions/workflows/release.yml) via **Run workflow**.
+You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
 
-## Version Pinning for Users
+## Version Bumping
 
-Users can install specific versions via git URL:
+Changesets determines the next version from the committed changeset files:
 
-```text
-# Latest
-https://github.com/PostHog/posthog-unity.git?path=com.posthog.unity
-
-# Specific version
-https://github.com/PostHog/posthog-unity.git?path=com.posthog.unity#v0.1.0
-```
+- **patch**: bug fixes, documentation updates, and internal changes
+- **minor**: backwards-compatible features
+- **major**: breaking changes
 
 ## Troubleshooting
 
-### Release workflow didn't trigger
+### No changesets found
 
-The workflow only triggers when:
-
-- A PR with the `release` label is merged to `main`
-- Or manually via workflow_dispatch
-
-### "No changesets found" error
-
-Ensure your PR includes a changeset file in `.changeset/`. Run `pnpm changeset` to create one.
-
-### Need to re-run a failed release
-
-Go to [Actions > Release](../../actions/workflows/release.yml) and click **Run workflow**.
+If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,45 +1,93 @@
 # Releasing
 
-This repository uses [Changesets](https://github.com/changesets/changesets) for version management and an automated GitHub Actions workflow for releases.
+This document describes how to release a new version of the PostHog Unity SDK.
 
-## How to Release
+## Overview
 
-### 1. Add a Changeset
+Releases use [changesets](https://github.com/changesets/changesets) for version management and changelog generation:
 
-When making a change that should be released, add a changeset:
+1. Add a changeset to your PR describing the change
+2. Merge the PR — GitHub Actions handles the rest (no release label required)
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) (see `.nvmrc` for version)
+- [pnpm](https://pnpm.io/) installed (`npm install -g pnpm`)
+
+Run `pnpm install` to install dependencies.
+
+## Adding a Changeset
+
+When you make a change that should be included in the next release, add a changeset:
 
 ```bash
 pnpm changeset
 ```
 
-This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
+This will prompt you to:
 
-### 2. Merge the Pull Request
+1. Select the package(s) affected (`com.posthog.unity`)
+2. Choose the semver bump type (patch/minor/major)
+3. Write a summary of the change
 
-After review, merge the PR to `main`. No GitHub release label is required.
+The changeset file is created in `.changeset/` and should be committed with your PR.
 
-A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
+### Version Guidelines
+
+Follow [Semantic Versioning](https://semver.org/):
+
+- **patch**: Bug fixes, backwards compatible
+- **minor**: New features, backwards compatible
+- **major**: Breaking changes
+
+## Release Process
+
+### 1. Create your PR with a changeset
+
+Include a changeset file in your PR (created via `pnpm changeset`).
+
+### 2. Merge the PR
+
+No release label is required. When the PR is merged to `main`, the release workflow:
 
 1. Checks for pending changesets
-2. Notifies the client libraries team in Slack for approval
-3. Waits for approval from a maintainer via the GitHub `Release` environment
-4. The workflow applies Changesets, syncs Unity package versions, tags the release, and creates a GitHub Release.
-5. Notifies Slack when the release completes or fails
+2. Sends a Slack notification requesting approval
+3. On approval:
+   - Applies changesets (bumps version, updates CHANGELOG.md)
+   - Syncs version to `com.posthog.unity/package.json` and `SdkInfo.Generated.cs`
+   - Commits the version bump to `main`
+   - Creates a git tag (`vX.Y.Z`)
+   - Creates a GitHub Release with auto-generated notes
 
-### Manual Trigger
+### Manual trigger
 
-You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
+You can also trigger the release workflow manually from the [Actions tab](../../actions/workflows/release.yml) via **Run workflow**.
 
-## Version Bumping
+## Version Pinning for Users
 
-Changesets determines the next version from the committed changeset files:
+Users can install specific versions via git URL:
 
-- **patch**: bug fixes, documentation updates, and internal changes
-- **minor**: backwards-compatible features
-- **major**: breaking changes
+```text
+# Latest
+https://github.com/PostHog/posthog-unity.git?path=com.posthog.unity
+
+# Specific version
+https://github.com/PostHog/posthog-unity.git?path=com.posthog.unity#v0.1.0
+```
 
 ## Troubleshooting
 
-### No changesets found
+### Release workflow didn't trigger
 
-If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.
+The workflow only triggers when:
+
+- A PR with a changeset is merged to `main`
+- Or manually via workflow_dispatch
+
+### "No changesets found" error
+
+Ensure your PR includes a changeset file in `.changeset/`. Run `pnpm changeset` to create one.
+
+### Need to re-run a failed release
+
+Go to [Actions > Release](../../actions/workflows/release.yml) and click **Run workflow**.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ This prompts you to select the version bump (`patch`, `minor`, or `major`) and w
 
 After review, merge the PR to `main`. No GitHub release label is required.
 
-A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
+A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
 
 1. Checks for pending changesets
 2. Notifies the client libraries team in Slack for approval


### PR DESCRIPTION
## :bulb: Motivation and Context
Standardize SDK releases so they are triggered by pushes to `main` containing release changesets, rather than by PR labels or `pull_request.closed` events.

## Changes
- Updated the release workflow to run on `push` to `main` for `.changeset/**`, while keeping manual `workflow_dispatch`
- Removed release-label and bump-label checks from the release flow
- Added `[skip ci]` to release version-bump commits and narrowed release path filters to changeset markdown files to avoid re-triggering release workflows on consumed changeset deletions
- Updated only the release-label parts of the release docs and PR checklist

## :green_heart: How did you test it?
- Parsed the updated release workflow YAML locally
- Verified the release workflow no longer references `pull_request`, PR labels, or bump labels
- Verified PR templates no longer ask for release labels

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not needed for this release-process-only change)