### PR TITLE
Refactor error tracking and align with posthog-dotnet

### DIFF
--- a/.changeset/silver-ravens-hope.md
+++ b/.changeset/silver-ravens-hope.md
@@ -1,0 +1,5 @@
+---
+"com.posthog.unity": patch
+---
+
+Align Unity error tracking exception payloads with other PostHog SDKs and improve Unity/WebGL exception integration handling.

--- a/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs
@@ -77,7 +77,7 @@ namespace PostHogUnity.ErrorTracking
                 ["value"] = exceptionMessage,
                 ["mechanism"] = new Dictionary<string, object>
                 {
-                    ["type"] = handled ? "generic" : "unity.log",
+                    ["type"] = "generic",
                     ["handled"] = handled,
                     ["source"] = "unity",
                     ["synthetic"] = true,
@@ -124,7 +124,7 @@ namespace PostHogUnity.ErrorTracking
                         ["value"] = ex.Message,
                         ["mechanism"] = new Dictionary<string, object>
                         {
-                            ["type"] = handled ? "generic" : "unity.LogException",
+                            ["type"] = "generic",
                             ["handled"] = handled,
                             ["source"] = "unity",
                             ["synthetic"] = false,

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs
@@ -60,23 +60,29 @@ namespace PostHogUnity.ErrorTracking
 
         void ILogHandler.LogException(Exception exception, UnityObject context)
         {
-            // Report to our consumer before forwarding so it observes the
-            // exception even if the original handler decides to terminate
-            // (e.g. in some edit-mode contexts).
-            var callback = _onException;
-            if (callback != null && exception != null)
+            // The forward-to-previous call lives in `finally` so we still
+            // chain even if the callback or its logger fault. PostHogLogger
+            // routes through Debug.LogError, which can re-enter this same
+            // integration and surface whatever the host handler does.
+            try
             {
-                try
+                var callback = _onException;
+                if (callback != null && exception != null)
                 {
-                    callback(exception);
-                }
-                catch (Exception failure)
-                {
-                    PostHogLogger.Error("Exception callback threw", failure);
+                    try
+                    {
+                        callback(exception);
+                    }
+                    catch (Exception failure)
+                    {
+                        PostHogLogger.Error("Exception callback threw", failure);
+                    }
                 }
             }
-
-            _previous?.LogException(exception, context);
+            finally
+            {
+                _previous?.LogException(exception, context);
+            }
         }
 
         void ILogHandler.LogFormat(

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs
@@ -1,114 +1,92 @@
 using System;
 using UnityEngine;
+using UnityObject = UnityEngine.Object;
 
 namespace PostHogUnity.ErrorTracking
 {
     /// <summary>
-    /// Intercepts Unity's log handler to capture Debug.LogException calls with actual exception objects.
-    /// This is used on non-WebGL platforms where Debug.unityLogger.logHandler works correctly.
+    /// Hooks into Unity's logging pipeline by replacing the active
+    /// <see cref="ILogHandler"/> on <see cref="Debug.unityLogger"/>. Any
+    /// <see cref="ILogHandler.LogException"/> call is reported through the
+    /// supplied callback and then passed to the previously installed handler
+    /// so existing logging behaviour is preserved.
     /// </summary>
     sealed class UnityExceptionIntegration : ILogHandler
     {
-        ILogHandler _originalLogHandler;
-        Action<Exception> _captureCallback;
-        bool _isRegistered;
+        Action<Exception> _onException;
+        ILogHandler _previous;
+        bool _installed;
 
         /// <summary>
-        /// Registers this integration by replacing Unity's log handler.
+        /// Installs this instance as Unity's active log handler and remembers
+        /// the previous one for chaining. Calling twice without an intervening
+        /// <see cref="Unregister"/> logs a warning and does nothing.
         /// </summary>
-        /// <param name="captureCallback">Callback to invoke when an exception is captured</param>
-        public void Register(Action<Exception> captureCallback)
+        public void Register(Action<Exception> onException)
         {
-            if (_isRegistered)
+            if (_installed)
             {
-                PostHogLogger.Warning("UnityExceptionIntegration has already been registered.");
+                PostHogLogger.Warning("UnityExceptionIntegration is already registered");
                 return;
             }
 
-            // Safety check: don't register if we're already the log handler
-            if (Debug.unityLogger.logHandler == this)
-            {
-                PostHogLogger.Warning("UnityExceptionIntegration is already the log handler.");
-                return;
-            }
-
-            _captureCallback = captureCallback;
-            _originalLogHandler = Debug.unityLogger.logHandler;
+            _onException = onException;
+            _previous = Debug.unityLogger.logHandler;
             Debug.unityLogger.logHandler = this;
-            _isRegistered = true;
-
-            PostHogLogger.Debug("UnityExceptionIntegration registered");
+            _installed = true;
         }
 
         /// <summary>
-        /// Unregisters this integration and restores the original log handler.
+        /// Restores the prior log handler if this instance is still the active
+        /// one. If a third party replaced the handler in between, the current
+        /// handler is left in place.
         /// </summary>
         public void Unregister()
         {
-            if (!_isRegistered)
+            if (!_installed)
             {
                 return;
             }
 
-            // Only restore if we're still the log handler
-            if (Debug.unityLogger.logHandler == this && _originalLogHandler != null)
+            if (ReferenceEquals(Debug.unityLogger.logHandler, this))
             {
-                Debug.unityLogger.logHandler = _originalLogHandler;
+                Debug.unityLogger.logHandler = _previous;
             }
 
-            _isRegistered = false;
-            _captureCallback = null;
-
-            PostHogLogger.Debug("UnityExceptionIntegration unregistered");
+            _previous = null;
+            _onException = null;
+            _installed = false;
         }
 
-        /// <summary>
-        /// Called by Unity when Debug.LogException is invoked.
-        /// </summary>
-        public void LogException(Exception exception, UnityEngine.Object context)
+        void ILogHandler.LogException(Exception exception, UnityObject context)
         {
-            try
+            // Report to our consumer before forwarding so it observes the
+            // exception even if the original handler decides to terminate
+            // (e.g. in some edit-mode contexts).
+            var callback = _onException;
+            if (callback != null && exception != null)
             {
-                ProcessException(exception);
+                try
+                {
+                    callback(exception);
+                }
+                catch (Exception failure)
+                {
+                    PostHogLogger.Error("Exception callback threw", failure);
+                }
             }
-            finally
-            {
-                // Always pass the exception back to Unity's original handler
-                _originalLogHandler?.LogException(exception, context);
-            }
+
+            _previous?.LogException(exception, context);
         }
 
-        /// <summary>
-        /// Called by Unity for non-exception log messages.
-        /// </summary>
-        public void LogFormat(
+        void ILogHandler.LogFormat(
             LogType logType,
-            UnityEngine.Object context,
+            UnityObject context,
             string format,
             params object[] args
         )
         {
-            // Pass through to original handler
-            // We don't capture regular log messages here - that's handled separately
-            _originalLogHandler?.LogFormat(logType, context, format, args);
-        }
-
-        void ProcessException(Exception exception)
-        {
-            if (exception == null)
-            {
-                return;
-            }
-
-            try
-            {
-                _captureCallback?.Invoke(exception);
-            }
-            catch (Exception e)
-            {
-                // Never let an exception in our callback propagate and break user code
-                PostHogLogger.Error("Error processing exception in PostHog", e);
-            }
+            _previous?.LogFormat(logType, context, format, args);
         }
     }
 }

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs
@@ -93,9 +93,7 @@ namespace PostHogUnity.ErrorTracking
                             module: method?.DeclaringType?.FullName ?? "",
                             function: method?.Name ?? "",
                             absPath: absPath ?? "",
-                            filename: string.IsNullOrEmpty(absPath)
-                                ? ""
-                                : ExtractLeafName(absPath),
+                            filename: string.IsNullOrEmpty(absPath) ? "" : ExtractLeafName(absPath),
                             lineNo: sourceLine > 0 ? sourceLine : null,
                             colNo: sourceColumn > 0 ? sourceColumn : null
                         )

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs
@@ -1,209 +1,256 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Diagnostics;
 
 namespace PostHogUnity.ErrorTracking
 {
     /// <summary>
-    /// Parses Unity-formatted stacktraces into structured stack frames.
+    /// Converts Unity-formatted stack trace strings and .NET exceptions into the
+    /// frame-dictionary structure used by PostHog's error tracking wire format.
     /// </summary>
     static class UnityStackTraceParser
     {
-        const string AtFileMarker = " (at ";
+        const string LocationMarker = " (at ";
+        static readonly char[] PathSeparators = { '/', '\\' };
 
         /// <summary>
-        /// Parses a Unity stacktrace string into structured stack frames.
+        /// Parses a Unity stack trace string into an ordered list of frame dictionaries.
+        /// Every non-empty input line produces exactly one frame: lines that match the
+        /// <c>Module:Method (args) (at path:line)</c> shape are decomposed into a
+        /// function name and location, and lines that don't are preserved verbatim
+        /// under <c>function</c> so diagnostic context isn't lost.
         /// </summary>
-        /// <param name="stackTrace">The Unity stacktrace string to parse</param>
-        /// <returns>A list of parsed stack frame dictionaries</returns>
         public static List<Dictionary<string, object>> Parse(string stackTrace)
         {
-            // Example: Sentry.Unity.Integrations.UnityLogHandlerIntegration:LogFormat (UnityEngine.LogType,UnityEngine.Object,string,object[]) (at UnityLogHandlerIntegration.cs:89)
-            // This follows the following format:
-            // Module.Class:Method[.Invoke] (arguments) (at filepath:linenumber)
-            // The ':linenumber' is optional and will be omitted in builds
-
             var frames = new List<Dictionary<string, object>>();
-
             if (string.IsNullOrEmpty(stackTrace))
             {
                 return frames;
             }
 
-            var stackList = stackTrace.Split('\n');
-
-            foreach (var line in stackList)
+            try
             {
-                var item = line.TrimEnd('\r');
-                if (string.IsNullOrEmpty(item))
+                foreach (var rawLine in stackTrace.Split('\n'))
                 {
-                    continue;
-                }
+                    var line = rawLine.Trim();
+                    if (line.Length == 0)
+                    {
+                        continue;
+                    }
 
-                var frame = ParseStackFrame(item);
-                frames.Add(frame);
+                    frames.Add(ReadTextFrame(line));
+                }
+            }
+            catch (Exception ex)
+            {
+                PostHogLogger.Error("UnityStackTraceParser.Parse failed", ex);
             }
 
             return frames;
         }
 
         /// <summary>
-        /// Parses a .NET Exception's stack trace into structured stack frames.
+        /// Walks the frames of a .NET <see cref="Exception"/> using
+        /// <see cref="StackTrace"/> and emits them in the same wire format. When the
+        /// runtime can't materialise structured frames (common on IL2CPP/AOT builds
+        /// where <see cref="StackTrace.GetFrames"/> returns <c>null</c>), falls back
+        /// to parsing <see cref="Exception.StackTrace"/> as text so we still ship
+        /// usable stack data.
         /// </summary>
-        /// <param name="exception">The exception to parse</param>
-        /// <returns>A list of parsed stack frame dictionaries</returns>
         public static List<Dictionary<string, object>> ParseException(Exception exception)
         {
             var frames = new List<Dictionary<string, object>>();
-
             if (exception == null)
             {
                 return frames;
             }
 
-            var stackTrace = new System.Diagnostics.StackTrace(exception, true);
-            var stackFrames = stackTrace.GetFrames();
-
-            if (stackFrames == null)
+            try
             {
-                // Fall back to parsing the string representation
-                if (!string.IsNullOrEmpty(exception.StackTrace))
+                var trace = new StackTrace(exception, fNeedFileInfo: true);
+                var stackFrames = trace.GetFrames();
+                if (stackFrames == null)
                 {
-                    return Parse(exception.StackTrace);
+                    return string.IsNullOrEmpty(exception.StackTrace)
+                        ? frames
+                        : Parse(exception.StackTrace);
                 }
-                return frames;
-            }
 
-            foreach (var frame in stackFrames)
-            {
-                var method = frame.GetMethod();
-                var fileName = frame.GetFileName();
-                var lineNumber = frame.GetFileLineNumber();
-                var columnNumber = frame.GetFileColumnNumber();
-
-                var frameDetails = new Dictionary<string, object>
+                foreach (var sf in stackFrames)
                 {
-                    ["platform"] = "custom",
-                    ["lang"] = "csharp",
-                    ["filename"] = string.IsNullOrEmpty(fileName) ? "" : Path.GetFileName(fileName),
-                    ["abs_path"] = fileName ?? "",
-                    ["function"] = method?.Name ?? "",
-                    ["module"] = method?.DeclaringType?.FullName ?? "",
-                    ["lineno"] = lineNumber > 0 ? (object)lineNumber : null,
-                    ["colno"] = columnNumber > 0 ? (object)columnNumber : null,
-                };
+                    if (sf == null)
+                    {
+                        continue;
+                    }
 
-                frames.Add(frameDetails);
+                    var method = sf.GetMethod();
+                    var absPath = sf.GetFileName();
+                    var sourceLine = sf.GetFileLineNumber();
+                    var sourceColumn = sf.GetFileColumnNumber();
+
+                    frames.Add(
+                        BuildFrame(
+                            module: method?.DeclaringType?.FullName ?? "",
+                            function: method?.Name ?? "",
+                            absPath: absPath ?? "",
+                            filename: string.IsNullOrEmpty(absPath)
+                                ? ""
+                                : ExtractLeafName(absPath),
+                            lineNo: sourceLine > 0 ? sourceLine : null,
+                            colNo: sourceColumn > 0 ? sourceColumn : null
+                        )
+                    );
+                }
+            }
+            catch (Exception ex)
+            {
+                PostHogLogger.Error("UnityStackTraceParser.ParseException failed", ex);
             }
 
             return frames;
         }
 
-        static Dictionary<string, object> ParseStackFrame(string stackFrameLine)
+        static Dictionary<string, object> ReadTextFrame(string line)
         {
-            var closingParenthesis = stackFrameLine.IndexOf(')');
-            if (closingParenthesis == -1)
+            // The function signature ends at the first ')'. Lines without one
+            // (header lines like "Rethrow as …", continuation markers, malformed
+            // entries) become a basic frame so the raw line stays visible.
+            var firstClose = line.IndexOf(')');
+            if (firstClose < 0)
             {
-                return CreateBasicStackFrame(stackFrameLine);
+                return BuildBasicFrame(line);
             }
 
-            try
+            var function = line.Substring(0, firstClose + 1);
+            var afterFunction = line.Substring(firstClose + 1);
+
+            var markerIndex = afterFunction.IndexOf(LocationMarker, StringComparison.Ordinal);
+            if (markerIndex < 0)
             {
-                var functionName = stackFrameLine.Substring(0, closingParenthesis + 1);
-                var remainingText = stackFrameLine.Substring(closingParenthesis + 1);
-
-                if (!remainingText.Contains(AtFileMarker))
-                {
-                    // If it does not contain '(at' it's an unknown format or no file info
-                    return CreateBasicStackFrame(functionName);
-                }
-
-                var (filename, lineNo) = ParseFileLocation(remainingText);
-                var filenameWithoutZeroes = StripZeroes(filename);
-
-                return new Dictionary<string, object>
-                {
-                    ["platform"] = "custom",
-                    ["lang"] = "csharp",
-                    ["filename"] = TryResolveFileNameForMono(filenameWithoutZeroes),
-                    ["abs_path"] = filenameWithoutZeroes,
-                    ["function"] = functionName,
-                    ["lineno"] = lineNo == -1 ? null : (object)lineNo,
-                };
+                return BuildBasicFrame(function);
             }
-            catch
+
+            var locationStart = markerIndex + LocationMarker.Length;
+            var locationEnd = afterFunction.LastIndexOf(')');
+            if (locationEnd <= locationStart)
             {
-                // Suppress any errors while parsing and fall back to a basic stackframe
-                return CreateBasicStackFrame(stackFrameLine);
+                return BuildBasicFrame(function);
             }
+
+            var rawLocation = afterFunction.Substring(locationStart, locationEnd - locationStart);
+            var (absPath, filename, lineNo) = ResolveLocation(rawLocation);
+
+            return BuildFrame(
+                module: null,
+                function: function,
+                absPath: absPath,
+                filename: filename,
+                lineNo: lineNo,
+                colNo: null
+            );
         }
 
-        static (string Filename, int LineNo) ParseFileLocation(string location)
-        {
-            var atIndex = location.IndexOf(AtFileMarker);
-            if (atIndex == -1)
-            {
-                return (location, -1);
-            }
-
-            // Remove " (at " prefix and trailing ")"
-            var startIndex = atIndex + AtFileMarker.Length;
-            var endIndex = location.LastIndexOf(')');
-            if (endIndex <= startIndex)
-            {
-                return (location.Substring(startIndex), -1);
-            }
-
-            var fileInfo = location.Substring(startIndex, endIndex - startIndex);
-            var lastColon = fileInfo.LastIndexOf(':');
-
-            if (lastColon == -1)
-            {
-                return (fileInfo, -1);
-            }
-
-            var lineStr = fileInfo.Substring(lastColon + 1);
-            if (int.TryParse(lineStr, out var lineNo))
-            {
-                return (fileInfo.Substring(0, lastColon), lineNo);
-            }
-
-            return (fileInfo, -1);
-        }
-
-        static Dictionary<string, object> CreateBasicStackFrame(string functionName)
-        {
-            return new Dictionary<string, object>
+        static Dictionary<string, object> BuildBasicFrame(string function) =>
+            new Dictionary<string, object>
             {
                 ["platform"] = "custom",
                 ["lang"] = "csharp",
-                ["function"] = functionName,
                 ["filename"] = null,
                 ["abs_path"] = null,
+                ["function"] = function,
+                ["module"] = null,
                 ["lineno"] = null,
+                ["colno"] = null,
             };
+
+        static Dictionary<string, object> BuildFrame(
+            string module,
+            string function,
+            string absPath,
+            string filename,
+            int? lineNo,
+            int? colNo
+        ) =>
+            new Dictionary<string, object>
+            {
+                ["platform"] = "custom",
+                ["lang"] = "csharp",
+                ["filename"] = filename,
+                ["abs_path"] = absPath,
+                ["function"] = function,
+                ["module"] = module,
+                ["lineno"] = lineNo,
+                ["colno"] = colNo,
+            };
+
+        static (string absPath, string filename, int? lineNo) ResolveLocation(string raw)
+        {
+            if (string.IsNullOrEmpty(raw))
+            {
+                return (null, null, null);
+            }
+
+            var path = raw;
+            int? lineNo = null;
+            var lastColon = raw.LastIndexOf(':');
+            if (lastColon > 0 && lastColon < raw.Length - 1)
+            {
+                var tail = raw.Substring(lastColon + 1);
+                if (int.TryParse(tail, out var parsedLine))
+                {
+                    path = raw.Substring(0, lastColon);
+                    lineNo = parsedLine;
+                }
+            }
+
+            // IL2CPP emits "<00…00>" when source info isn't available; surface
+            // the location as empty strings so consumers see "unknown" instead
+            // of a misleading placeholder path.
+            if (LooksLikeIl2CppPlaceholder(path))
+            {
+                return ("", "", lineNo);
+            }
+
+            return (path, ExtractLeafName(path), lineNo);
         }
 
-        // https://github.com/getsentry/sentry-unity/issues/103
-        static string StripZeroes(string filename)
+        static bool LooksLikeIl2CppPlaceholder(string path)
         {
-            return filename.Replace("0", "").Equals("<>", StringComparison.OrdinalIgnoreCase)
-                ? string.Empty
-                : filename;
+            if (string.IsNullOrEmpty(path) || path.Length < 3)
+            {
+                return false;
+            }
+
+            if (path[0] != '<' || path[path.Length - 1] != '>')
+            {
+                return false;
+            }
+
+            for (var i = 1; i < path.Length - 1; i++)
+            {
+                if (path[i] != '0')
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
-        static string TryResolveFileNameForMono(string fileName)
+        static string ExtractLeafName(string path)
         {
-            try
+            if (string.IsNullOrEmpty(path))
             {
-                // throws on Mono for <1231231231> paths
-                return Path.GetFileName(fileName);
+                return null;
             }
-            catch
+
+            var separator = path.LastIndexOfAny(PathSeparators);
+            if (separator >= 0 && separator < path.Length - 1)
             {
-                // mono path
-                return "Unknown";
+                return path.Substring(separator + 1);
             }
+
+            return path;
         }
     }
 }

--- a/com.posthog.unity/Runtime/ErrorTracking/WebGLExceptionIntegration.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/WebGLExceptionIntegration.cs
@@ -4,72 +4,85 @@ using UnityEngine;
 namespace PostHogUnity.ErrorTracking
 {
     /// <summary>
-    /// WebGL-specific exception handler that captures exceptions through Application.logMessageReceived.
-    /// Required because UnityExceptionIntegration (Debug.unityLogger.logHandler) doesn't work on WebGL.
+    /// Captures uncaught exceptions on platforms (notably WebGL) where the
+    /// <see cref="ILogHandler"/> replacement strategy isn't reliable. Listens
+    /// to <see cref="Application.logMessageReceived"/> and forwards only the
+    /// entries with <see cref="LogType.Exception"/>.
     /// </summary>
     sealed class WebGLExceptionIntegration
     {
-        Action<string, string> _captureCallback;
-        bool _isRegistered;
+        const string SdkLogPrefix = "[PostHog]";
+
+        Action<string, string> _callback;
+        Application.LogCallback _subscription;
+        bool _subscribed;
 
         /// <summary>
-        /// Registers this integration to listen for log messages.
+        /// Begins listening for Unity log messages. The provided callback is
+        /// invoked with the message condition and its associated stack trace
+        /// whenever an exception entry is received.
         /// </summary>
-        /// <param name="captureCallback">Callback to invoke when an exception is captured (message, stackTrace)</param>
-        public void Register(Action<string, string> captureCallback)
+        public void Register(Action<string, string> onException)
         {
-            if (_isRegistered)
+            if (_subscribed)
             {
-                PostHogLogger.Warning("WebGLExceptionIntegration has already been registered.");
+                PostHogLogger.Warning("WebGLExceptionIntegration is already registered");
                 return;
             }
 
-            _captureCallback = captureCallback;
-            Application.logMessageReceived += OnLogMessageReceived;
-            _isRegistered = true;
-
-            PostHogLogger.Debug("WebGLExceptionIntegration registered");
+            _callback = onException;
+            _subscription = HandleLogMessage;
+            Application.logMessageReceived += _subscription;
+            _subscribed = true;
         }
 
         /// <summary>
-        /// Unregisters this integration and stops listening for log messages.
+        /// Detaches from <see cref="Application.logMessageReceived"/> and
+        /// clears the held callback.
         /// </summary>
         public void Unregister()
         {
-            if (!_isRegistered)
+            if (!_subscribed)
             {
                 return;
             }
 
-            Application.logMessageReceived -= OnLogMessageReceived;
-            _isRegistered = false;
-            _captureCallback = null;
-
-            PostHogLogger.Debug("WebGLExceptionIntegration unregistered");
+            Application.logMessageReceived -= _subscription;
+            _callback = null;
+            _subscription = null;
+            _subscribed = false;
         }
 
-        void OnLogMessageReceived(string condition, string stackTrace, LogType type)
+        void HandleLogMessage(string condition, string stackTrace, LogType type)
         {
-            // Only capture exceptions
             if (type != LogType.Exception)
             {
                 return;
             }
 
-            // Skip PostHog's own logs
-            if (condition.StartsWith("[PostHog]"))
+            // Drop messages that originate from PostHog's own logger so we
+            // can't recurse if the SDK itself logs an error during capture.
+            if (
+                !string.IsNullOrEmpty(condition)
+                && condition.StartsWith(SdkLogPrefix, StringComparison.Ordinal)
+            )
+            {
+                return;
+            }
+
+            var callback = _callback;
+            if (callback == null)
             {
                 return;
             }
 
             try
             {
-                _captureCallback?.Invoke(condition, stackTrace);
+                callback(condition, stackTrace);
             }
-            catch (Exception e)
+            catch (Exception failure)
             {
-                // Never let an exception in our callback propagate
-                PostHogLogger.Error("Error processing WebGL exception in PostHog", e);
+                PostHogLogger.Error("Exception callback threw", failure);
             }
         }
     }

--- a/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
+++ b/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
@@ -64,6 +64,31 @@ namespace PostHogUnity.Tests
         }
 
         /// <summary>
+        /// Records <c>LogException</c> calls but throws on every <c>LogFormat</c>
+        /// call. Used to simulate the case where <c>PostHogLogger.Error</c> itself
+        /// fails (it routes through <c>Debug.LogError</c>, which re-enters the
+        /// installed integration and ends up calling <c>LogFormat</c> on this).
+        /// </summary>
+        sealed class ThrowingLogFormatHandler : ILogHandler
+        {
+            public int LogExceptionCount;
+            public Exception LastException;
+
+            public void LogException(Exception exception, UnityEngine.Object context)
+            {
+                LogExceptionCount++;
+                LastException = exception;
+            }
+
+            public void LogFormat(
+                LogType logType,
+                UnityEngine.Object context,
+                string format,
+                params object[] args
+            ) => throw new InvalidOperationException("log handler broken");
+        }
+
+        /// <summary>
         /// Snapshots <c>Debug.unityLogger.logHandler</c> on construction and
         /// restores it on disposal. Uses the supplied test double in between so
         /// any internal <c>Debug.Log*</c> calls route through managed code.
@@ -216,6 +241,36 @@ namespace PostHogUnity.Tests
 
                 Assert.Null(thrown);
                 Assert.Equal(0, callbackInvocations);
+            }
+
+            [Fact]
+            public void WhenLoggerAlsoThrows_StillForwardsExceptionToPreviousHandler()
+            {
+                // The throwing handler stands in for a host log handler that
+                // misbehaves on LogFormat. When the callback fails and the SDK
+                // tries to PostHogLogger.Error the failure, the error log
+                // re-enters this integration's LogFormat, which forwards to
+                // the broken handler and raises. The forward-to-previous of
+                // the original exception must still happen.
+                var handler = new ThrowingLogFormatHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+                integration.Register(_ => throw new ApplicationException("callback boom"));
+
+                var raised = new InvalidOperationException("raise");
+                try
+                {
+                    ((ILogHandler)integration).LogException(raised, null);
+                }
+                catch
+                {
+                    // Whether the logger-induced exception propagates is not
+                    // the contract under test; the forwarding guarantee is.
+                }
+
+                Assert.Equal(1, handler.LogExceptionCount);
+                Assert.Same(raised, handler.LastException);
             }
         }
 

--- a/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
+++ b/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
@@ -1,0 +1,258 @@
+using PostHogUnity.ErrorTracking;
+using UnityEngine;
+
+namespace PostHogUnity.Tests
+{
+    /// <summary>
+    /// Serializes tests that mutate global Unity state (e.g. <c>Debug.unityLogger.logHandler</c>,
+    /// the <c>Application.logMessageReceived</c> backing field). Every nested test class in
+    /// <see cref="UnityExceptionIntegrationTests"/> and <see cref="WebGLExceptionIntegrationTests"/>
+    /// must opt in with <c>[Collection("UnityGlobals")]</c> — xUnit does not propagate the
+    /// outer-class attribute to nested test classes.
+    /// </summary>
+    [CollectionDefinition("UnityGlobals")]
+    public class UnityGlobalsCollection { }
+
+    /// <summary>
+    /// Characterization tests for <see cref="UnityExceptionIntegration"/>.
+    ///
+    /// Notes on the test seam:
+    ///   * The Unity3D.SDK stub package's <c>Debug.Log*</c> methods call into ECall
+    ///     (native code) and throw <c>SecurityException</c> when invoked from a
+    ///     standard .NET test host. To make any test that exercises code reaching
+    ///     <c>PostHogLogger</c> survive, every test below first swaps
+    ///     <c>Debug.unityLogger.logHandler</c> for a recording test double via
+    ///     <see cref="HandlerScope"/>. With the swap in place, <c>Debug.LogWarning</c>
+    ///     / <c>Debug.LogError</c> route through managed code into the test double
+    ///     rather than into the native stub.
+    ///   * Tests in this collection share that global state and therefore run
+    ///     serially (see the <c>Collection</c> attribute).
+    /// </summary>
+    [Collection("UnityGlobals")]
+    public class UnityExceptionIntegrationTests
+    {
+        /// <summary>
+        /// Recording <see cref="ILogHandler"/> used as both the "original" log
+        /// handler the integration captures at <c>Register</c> time and the
+        /// stand-in to route any internal PostHog logging through.
+        /// </summary>
+        sealed class RecordingLogHandler : ILogHandler
+        {
+            public int LogExceptionCount;
+            public int LogFormatCount;
+            public Exception LastException;
+            public LogType LastLogType;
+            public string LastFormat;
+
+            public void LogException(Exception exception, UnityEngine.Object context)
+            {
+                LogExceptionCount++;
+                LastException = exception;
+            }
+
+            public void LogFormat(
+                LogType logType,
+                UnityEngine.Object context,
+                string format,
+                params object[] args
+            )
+            {
+                LogFormatCount++;
+                LastLogType = logType;
+                LastFormat = format;
+            }
+        }
+
+        /// <summary>
+        /// Snapshots <c>Debug.unityLogger.logHandler</c> on construction and
+        /// restores it on disposal. Uses the supplied test double in between so
+        /// any internal <c>Debug.Log*</c> calls route through managed code.
+        /// </summary>
+        sealed class HandlerScope : IDisposable
+        {
+            readonly ILogHandler _original;
+            public HandlerScope(ILogHandler handler)
+            {
+                _original = Debug.unityLogger.logHandler;
+                Debug.unityLogger.logHandler = handler;
+            }
+            public void Dispose()
+            {
+                Debug.unityLogger.logHandler = _original;
+            }
+        }
+
+        [Collection("UnityGlobals")]
+        public class TheRegisterMethod
+        {
+            [Fact]
+            public void AfterRegister_LogExceptionInvokesCallbackWithException()
+            {
+                var handler = new RecordingLogHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+                Exception captured = null;
+                integration.Register(ex => captured = ex);
+
+                var thrown = new InvalidOperationException("boom");
+                ((ILogHandler)integration).LogException(thrown, null);
+
+                Assert.Same(thrown, captured);
+            }
+
+            [Fact]
+            public void CallingRegisterTwice_DoesNotReplaceCallbackAndDoesNotThrow()
+            {
+                var handler = new RecordingLogHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+                Exception capturedByFirst = null;
+                Exception capturedBySecond = null;
+                integration.Register(ex => capturedByFirst = ex);
+
+                var thrown = Record.Exception(
+                    () => integration.Register(ex => capturedBySecond = ex)
+                );
+
+                Assert.Null(thrown);
+
+                var raised = new InvalidOperationException("test");
+                ((ILogHandler)integration).LogException(raised, null);
+
+                Assert.Same(raised, capturedByFirst);
+                Assert.Null(capturedBySecond);
+            }
+        }
+
+        [Collection("UnityGlobals")]
+        public class TheUnregisterMethod
+        {
+            [Fact]
+            public void AfterUnregister_LogExceptionDoesNotInvokeCallback()
+            {
+                var handler = new RecordingLogHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+                int callbackInvocations = 0;
+                integration.Register(_ => callbackInvocations++);
+                integration.Unregister();
+
+                ((ILogHandler)integration).LogException(new Exception("after"), null);
+
+                Assert.Equal(0, callbackInvocations);
+            }
+
+            [Fact]
+            public void WhenNotRegistered_DoesNotThrow()
+            {
+                var handler = new RecordingLogHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+
+                var thrown = Record.Exception(() => integration.Unregister());
+
+                Assert.Null(thrown);
+            }
+        }
+
+        [Collection("UnityGlobals")]
+        public class TheLogExceptionMethod
+        {
+            [Fact]
+            public void ForwardsToTheOriginalLogHandler()
+            {
+                var handler = new RecordingLogHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+                integration.Register(_ => { });
+
+                var raised = new InvalidOperationException("forward");
+                ((ILogHandler)integration).LogException(raised, null);
+
+                Assert.Equal(1, handler.LogExceptionCount);
+                Assert.Same(raised, handler.LastException);
+            }
+
+            [Fact]
+            public void WhenCallbackThrows_DoesNotPropagate()
+            {
+                var handler = new RecordingLogHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+                integration.Register(_ => throw new ApplicationException("callback failed"));
+
+                var raised = new InvalidOperationException("raise");
+                var thrown = Record.Exception(
+                    () => ((ILogHandler)integration).LogException(raised, null)
+                );
+
+                Assert.Null(thrown);
+                // The original handler still gets the exception.
+                Assert.Equal(1, handler.LogExceptionCount);
+                Assert.Same(raised, handler.LastException);
+            }
+
+            [Fact]
+            public void WithNullException_DoesNotInvokeCallback()
+            {
+                var handler = new RecordingLogHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+                int callbackInvocations = 0;
+                integration.Register(_ => callbackInvocations++);
+
+                var thrown = Record.Exception(
+                    () => ((ILogHandler)integration).LogException(null, null)
+                );
+
+                Assert.Null(thrown);
+                Assert.Equal(0, callbackInvocations);
+            }
+        }
+
+        [Collection("UnityGlobals")]
+        public class TheLogFormatMethod
+        {
+            [Fact]
+            public void DoesNotInvokeCallback()
+            {
+                var handler = new RecordingLogHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+                int callbackInvocations = 0;
+                integration.Register(_ => callbackInvocations++);
+
+                ((ILogHandler)integration).LogFormat(LogType.Error, null, "{0}", "msg");
+                ((ILogHandler)integration).LogFormat(LogType.Warning, null, "{0}", "msg");
+                ((ILogHandler)integration).LogFormat(LogType.Log, null, "{0}", "msg");
+                ((ILogHandler)integration).LogFormat(LogType.Assert, null, "{0}", "msg");
+
+                Assert.Equal(0, callbackInvocations);
+            }
+
+            [Fact]
+            public void ForwardsToTheOriginalLogHandler()
+            {
+                var handler = new RecordingLogHandler();
+                using var scope = new HandlerScope(handler);
+
+                var integration = new UnityExceptionIntegration();
+                integration.Register(_ => { });
+
+                ((ILogHandler)integration).LogFormat(LogType.Warning, null, "fmt", "arg");
+
+                Assert.Equal(1, handler.LogFormatCount);
+                Assert.Equal(LogType.Warning, handler.LastLogType);
+                Assert.Equal("fmt", handler.LastFormat);
+            }
+        }
+    }
+}

--- a/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
+++ b/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
@@ -277,8 +277,12 @@ namespace PostHogUnity.Tests
         [Collection("UnityGlobals")]
         public class TheLogFormatMethod
         {
-            [Fact]
-            public void DoesNotInvokeCallback()
+            [Theory]
+            [InlineData(LogType.Error)]
+            [InlineData(LogType.Warning)]
+            [InlineData(LogType.Log)]
+            [InlineData(LogType.Assert)]
+            public void DoesNotInvokeCallback(LogType logType)
             {
                 var handler = new RecordingLogHandler();
                 using var scope = new HandlerScope(handler);
@@ -287,10 +291,7 @@ namespace PostHogUnity.Tests
                 int callbackInvocations = 0;
                 integration.Register(_ => callbackInvocations++);
 
-                ((ILogHandler)integration).LogFormat(LogType.Error, null, "{0}", "msg");
-                ((ILogHandler)integration).LogFormat(LogType.Warning, null, "{0}", "msg");
-                ((ILogHandler)integration).LogFormat(LogType.Log, null, "{0}", "msg");
-                ((ILogHandler)integration).LogFormat(LogType.Assert, null, "{0}", "msg");
+                ((ILogHandler)integration).LogFormat(logType, null, "{0}", "msg");
 
                 Assert.Equal(0, callbackInvocations);
             }

--- a/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
+++ b/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
@@ -22,7 +22,7 @@ namespace PostHogUnity.Tests
     ///     standard .NET test host. To make any test that exercises code reaching
     ///     <c>PostHogLogger</c> survive, every test below first swaps
     ///     <c>Debug.unityLogger.logHandler</c> for a recording test double via
-    ///     <see cref="HandlerScope"/>. With the swap in place, <c>Debug.LogWarning</c>
+    ///     <see cref="UnityHandlerScope"/>. With the swap in place, <c>Debug.LogWarning</c>
     ///     / <c>Debug.LogError</c> route through managed code into the test double
     ///     rather than into the native stub.
     ///   * Tests in this collection share that global state and therefore run
@@ -88,27 +88,6 @@ namespace PostHogUnity.Tests
             ) => throw new InvalidOperationException("log handler broken");
         }
 
-        /// <summary>
-        /// Snapshots <c>Debug.unityLogger.logHandler</c> on construction and
-        /// restores it on disposal. Uses the supplied test double in between so
-        /// any internal <c>Debug.Log*</c> calls route through managed code.
-        /// </summary>
-        sealed class HandlerScope : IDisposable
-        {
-            readonly ILogHandler _original;
-
-            public HandlerScope(ILogHandler handler)
-            {
-                _original = Debug.unityLogger.logHandler;
-                Debug.unityLogger.logHandler = handler;
-            }
-
-            public void Dispose()
-            {
-                Debug.unityLogger.logHandler = _original;
-            }
-        }
-
         [Collection("UnityGlobals")]
         public class TheRegisterMethod
         {
@@ -116,7 +95,7 @@ namespace PostHogUnity.Tests
             public void AfterRegister_LogExceptionInvokesCallbackWithException()
             {
                 var handler = new RecordingLogHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
                 Exception captured = null;
@@ -132,7 +111,7 @@ namespace PostHogUnity.Tests
             public void CallingRegisterTwice_DoesNotReplaceCallbackAndDoesNotThrow()
             {
                 var handler = new RecordingLogHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
                 Exception capturedByFirst = null;
@@ -160,7 +139,7 @@ namespace PostHogUnity.Tests
             public void AfterUnregister_LogExceptionDoesNotInvokeCallback()
             {
                 var handler = new RecordingLogHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
                 int callbackInvocations = 0;
@@ -176,7 +155,7 @@ namespace PostHogUnity.Tests
             public void WhenNotRegistered_DoesNotThrow()
             {
                 var handler = new RecordingLogHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
 
@@ -193,7 +172,7 @@ namespace PostHogUnity.Tests
             public void ForwardsToTheOriginalLogHandler()
             {
                 var handler = new RecordingLogHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
                 integration.Register(_ => { });
@@ -209,7 +188,7 @@ namespace PostHogUnity.Tests
             public void WhenCallbackThrows_DoesNotPropagate()
             {
                 var handler = new RecordingLogHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
                 integration.Register(_ => throw new ApplicationException("callback failed"));
@@ -229,7 +208,7 @@ namespace PostHogUnity.Tests
             public void WithNullException_DoesNotInvokeCallback()
             {
                 var handler = new RecordingLogHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
                 int callbackInvocations = 0;
@@ -253,7 +232,7 @@ namespace PostHogUnity.Tests
                 // the broken handler and raises. The forward-to-previous of
                 // the original exception must still happen.
                 var handler = new ThrowingLogFormatHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
                 integration.Register(_ => throw new ApplicationException("callback boom"));
@@ -285,7 +264,7 @@ namespace PostHogUnity.Tests
             public void DoesNotInvokeCallback(LogType logType)
             {
                 var handler = new RecordingLogHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
                 int callbackInvocations = 0;
@@ -300,7 +279,7 @@ namespace PostHogUnity.Tests
             public void ForwardsToTheOriginalLogHandler()
             {
                 var handler = new RecordingLogHandler();
-                using var scope = new HandlerScope(handler);
+                using var scope = new UnityHandlerScope(handler);
 
                 var integration = new UnityExceptionIntegration();
                 integration.Register(_ => { });

--- a/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
+++ b/tests/PostHog.Unity.Tests/UnityExceptionIntegrationTests.cs
@@ -71,11 +71,13 @@ namespace PostHogUnity.Tests
         sealed class HandlerScope : IDisposable
         {
             readonly ILogHandler _original;
+
             public HandlerScope(ILogHandler handler)
             {
                 _original = Debug.unityLogger.logHandler;
                 Debug.unityLogger.logHandler = handler;
             }
+
             public void Dispose()
             {
                 Debug.unityLogger.logHandler = _original;
@@ -112,8 +114,8 @@ namespace PostHogUnity.Tests
                 Exception capturedBySecond = null;
                 integration.Register(ex => capturedByFirst = ex);
 
-                var thrown = Record.Exception(
-                    () => integration.Register(ex => capturedBySecond = ex)
+                var thrown = Record.Exception(() =>
+                    integration.Register(ex => capturedBySecond = ex)
                 );
 
                 Assert.Null(thrown);
@@ -188,8 +190,8 @@ namespace PostHogUnity.Tests
                 integration.Register(_ => throw new ApplicationException("callback failed"));
 
                 var raised = new InvalidOperationException("raise");
-                var thrown = Record.Exception(
-                    () => ((ILogHandler)integration).LogException(raised, null)
+                var thrown = Record.Exception(() =>
+                    ((ILogHandler)integration).LogException(raised, null)
                 );
 
                 Assert.Null(thrown);
@@ -208,8 +210,8 @@ namespace PostHogUnity.Tests
                 int callbackInvocations = 0;
                 integration.Register(_ => callbackInvocations++);
 
-                var thrown = Record.Exception(
-                    () => ((ILogHandler)integration).LogException(null, null)
+                var thrown = Record.Exception(() =>
+                    ((ILogHandler)integration).LogException(null, null)
                 );
 
                 Assert.Null(thrown);

--- a/tests/PostHog.Unity.Tests/UnityHandlerScope.cs
+++ b/tests/PostHog.Unity.Tests/UnityHandlerScope.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace PostHogUnity.Tests
+{
+    /// <summary>
+    /// Snapshots <c>Debug.unityLogger.logHandler</c> on construction and
+    /// restores it on disposal. Used by tests that need to swap the active
+    /// log handler for a test double so internal <c>Debug.Log*</c> calls
+    /// route through managed code (the Unity3D.SDK stub's native log path
+    /// throws <c>SecurityException</c> in the standard .NET test host).
+    /// </summary>
+    sealed class UnityHandlerScope : IDisposable
+    {
+        readonly ILogHandler _original;
+
+        public UnityHandlerScope(ILogHandler handler)
+        {
+            _original = Debug.unityLogger.logHandler;
+            Debug.unityLogger.logHandler = handler;
+        }
+
+        public void Dispose()
+        {
+            Debug.unityLogger.logHandler = _original;
+        }
+    }
+}

--- a/tests/PostHog.Unity.Tests/UnityStackTraceParserTests.cs
+++ b/tests/PostHog.Unity.Tests/UnityStackTraceParserTests.cs
@@ -1,0 +1,338 @@
+using PostHogUnity.ErrorTracking;
+
+namespace PostHogUnity.Tests
+{
+    public class UnityStackTraceParserTests
+    {
+        public class TheParseMethod
+        {
+            [Fact]
+            public void WithNullInput_ReturnsEmptyList()
+            {
+                var frames = UnityStackTraceParser.Parse(null);
+
+                Assert.Empty(frames);
+            }
+
+            [Fact]
+            public void WithEmptyString_ReturnsEmptyList()
+            {
+                var frames = UnityStackTraceParser.Parse(string.Empty);
+
+                Assert.Empty(frames);
+            }
+
+            [Fact]
+            public void WithLineThatHasNoFileMarker_PopulatesFunctionAndLeavesFileFieldsNull()
+            {
+                var line = "SomeNamespace.SomeClass:SomeMethod (System.Int32,System.String)";
+
+                var frames = UnityStackTraceParser.Parse(line);
+
+                Assert.Single(frames);
+                var frame = frames[0];
+                Assert.Equal(line, frame["function"]);
+                Assert.Null(frame["filename"]);
+                Assert.Null(frame["abs_path"]);
+                Assert.Null(frame["lineno"]);
+            }
+
+            [Fact]
+            public void WithLineThatHasNoParensAtAll_UsesRawLineAsFunction()
+            {
+                var line = "JustAFunctionName";
+
+                var frames = UnityStackTraceParser.Parse(line);
+
+                Assert.Single(frames);
+                var frame = frames[0];
+                Assert.Equal(line, frame["function"]);
+                Assert.Null(frame["filename"]);
+                Assert.Null(frame["abs_path"]);
+                Assert.Null(frame["lineno"]);
+            }
+
+            [Fact]
+            public void WithFileAndLineNumber_PopulatesFilenameAbsPathAndLineno()
+            {
+                var line =
+                    "SomeNamespace.SomeClass:SomeMethod (System.Int32,System.String) (at Assets/Foo/Bar.cs:42)";
+
+                var frames = UnityStackTraceParser.Parse(line);
+
+                Assert.Single(frames);
+                var frame = frames[0];
+                Assert.Equal(
+                    "SomeNamespace.SomeClass:SomeMethod (System.Int32,System.String)",
+                    frame["function"]
+                );
+                Assert.Equal("Bar.cs", frame["filename"]);
+                Assert.Equal("Assets/Foo/Bar.cs", frame["abs_path"]);
+                Assert.Equal(42, frame["lineno"]);
+            }
+
+            [Fact]
+            public void WithFileButNoLineNumber_LeavesLinenoNull()
+            {
+                var line = "Foo.Bar:Baz () (at Assets/Foo/Bar.cs)";
+
+                var frames = UnityStackTraceParser.Parse(line);
+
+                Assert.Single(frames);
+                var frame = frames[0];
+                Assert.Equal("Foo.Bar:Baz ()", frame["function"]);
+                Assert.Equal("Bar.cs", frame["filename"]);
+                Assert.Equal("Assets/Foo/Bar.cs", frame["abs_path"]);
+                Assert.Null(frame["lineno"]);
+            }
+
+            [Fact]
+            public void WithIl2CppPlaceholderAndZeroLineNumber_StripsToEmptyAndPinsLinenoAsZero()
+            {
+                // The IL2CPP placeholder strips to empty strings (not null) to
+                // signal "location intentionally unknown". Lineno follows the
+                // raw input verbatim, so :0 becomes 0 rather than null.
+                var line = "SomeClass:Foo () (at <00000000>:0)";
+
+                var frames = UnityStackTraceParser.Parse(line);
+
+                Assert.Single(frames);
+                var frame = frames[0];
+                Assert.Equal("SomeClass:Foo ()", frame["function"]);
+                Assert.Equal("", frame["filename"]);
+                Assert.Equal("", frame["abs_path"]);
+                Assert.Equal(0, frame["lineno"]);
+            }
+
+            [Fact]
+            public void WithIl2CppPlaceholderAndNoLineNumber_StripsToEmptyAndLeavesLinenoNull()
+            {
+                var line = "SomeClass:Foo () (at <00000000>)";
+
+                var frames = UnityStackTraceParser.Parse(line);
+
+                Assert.Single(frames);
+                var frame = frames[0];
+                Assert.Equal("SomeClass:Foo ()", frame["function"]);
+                Assert.Equal("", frame["filename"]);
+                Assert.Equal("", frame["abs_path"]);
+                Assert.Null(frame["lineno"]);
+            }
+
+            [Fact]
+            public void WithMultipleLines_ReturnsFramesInSourceOrder()
+            {
+                var trace = string.Join(
+                    "\n",
+                    "A.B:First () (at Assets/A.cs:1)",
+                    "A.B:Second () (at Assets/A.cs:2)",
+                    "A.B:Third () (at Assets/A.cs:3)"
+                );
+
+                var frames = UnityStackTraceParser.Parse(trace);
+
+                Assert.Equal(3, frames.Count);
+                Assert.Equal("A.B:First ()", frames[0]["function"]);
+                Assert.Equal(1, frames[0]["lineno"]);
+                Assert.Equal("A.B:Second ()", frames[1]["function"]);
+                Assert.Equal(2, frames[1]["lineno"]);
+                Assert.Equal("A.B:Third ()", frames[2]["function"]);
+                Assert.Equal(3, frames[2]["lineno"]);
+            }
+
+            [Fact]
+            public void WithCrLfLineEndings_ToleratesTrailingCarriageReturn()
+            {
+                var trace = "A.B:First () (at Assets/A.cs:1)\r\nA.B:Second () (at Assets/B.cs:2)\r\n";
+
+                var frames = UnityStackTraceParser.Parse(trace);
+
+                Assert.Equal(2, frames.Count);
+                Assert.Equal("Assets/A.cs", frames[0]["abs_path"]);
+                Assert.Equal(1, frames[0]["lineno"]);
+                Assert.Equal("Assets/B.cs", frames[1]["abs_path"]);
+                Assert.Equal(2, frames[1]["lineno"]);
+            }
+
+            [Fact]
+            public void WithBlankLinesBetweenFrames_SkipsThem()
+            {
+                var trace = "\nA.B:First () (at Assets/A.cs:1)\n\n\nA.B:Second () (at Assets/A.cs:2)\n";
+
+                var frames = UnityStackTraceParser.Parse(trace);
+
+                Assert.Equal(2, frames.Count);
+                Assert.Equal("A.B:First ()", frames[0]["function"]);
+                Assert.Equal("A.B:Second ()", frames[1]["function"]);
+            }
+
+            [Fact]
+            public void EveryFrameHasCustomPlatformAndCsharpLang()
+            {
+                var trace = string.Join(
+                    "\n",
+                    "NoFileMarker",
+                    "A.B:Foo ()",
+                    "A.B:Bar () (at Assets/X.cs:10)",
+                    "A.B:Baz () (at <00000000>:0)"
+                );
+
+                var frames = UnityStackTraceParser.Parse(trace);
+
+                Assert.Equal(4, frames.Count);
+                foreach (var frame in frames)
+                {
+                    Assert.Equal("custom", frame["platform"]);
+                    Assert.Equal("csharp", frame["lang"]);
+                }
+            }
+
+            [Fact]
+            public void WithMalformedLineMissingClosingParen_DoesNotThrowAndPreservesRawLine()
+            {
+                var line = "Broken.Method (";
+
+                List<Dictionary<string, object>> frames = null;
+                var ex = Record.Exception(() => frames = UnityStackTraceParser.Parse(line));
+
+                Assert.Null(ex);
+                Assert.Single(frames);
+                Assert.Equal(line, frames[0]["function"]);
+                Assert.Null(frames[0]["filename"]);
+                Assert.Null(frames[0]["abs_path"]);
+                Assert.Null(frames[0]["lineno"]);
+            }
+
+            [Fact]
+            public void WithHeaderLikeRethrowLine_PreservesRawLineAsFunction()
+            {
+                // Lines without a ')' (rethrow markers, "End of stack trace" markers,
+                // JS-style "at fn (file.js:1:1)" entries from WebGL builds) must
+                // remain in the frame list so the captured stack stays diagnostic.
+                var line = "Rethrow as InvalidOperationException: boom";
+
+                var frames = UnityStackTraceParser.Parse(line);
+
+                Assert.Single(frames);
+                Assert.Equal(line, frames[0]["function"]);
+                Assert.Null(frames[0]["abs_path"]);
+            }
+
+            [Fact]
+            public void WithWindowsStylePath_ExtractsLeafFilenameUsingBackslash()
+            {
+                var line = @"MyGame.Player:Update () (at C:\Projects\Game\Assets\Player.cs:99)";
+
+                var frames = UnityStackTraceParser.Parse(line);
+
+                var frame = Assert.Single(frames);
+                Assert.Equal(@"C:\Projects\Game\Assets\Player.cs", frame["abs_path"]);
+                Assert.Equal("Player.cs", frame["filename"]);
+                Assert.Equal(99, frame["lineno"]);
+            }
+        }
+
+        public class TheParseExceptionMethod
+        {
+            // The eight contract keys that every ParseException frame must carry. If any
+            // frame is missing one of these keys, the dictionary lookup below will throw
+            // KeyNotFoundException — flagging a behavior change in the wire format.
+            static readonly string[] ContractKeys =
+            {
+                "platform",
+                "lang",
+                "filename",
+                "abs_path",
+                "function",
+                "module",
+                "lineno",
+                "colno",
+            };
+
+            static readonly Exception ThrownException = Capture();
+
+            static Exception Capture()
+            {
+                try
+                {
+                    throw new InvalidOperationException("characterization");
+                }
+                catch (Exception e)
+                {
+                    return e;
+                }
+            }
+
+            [Fact]
+            public void WithNullInput_ReturnsEmptyList()
+            {
+                var frames = UnityStackTraceParser.ParseException(null);
+
+                Assert.Empty(frames);
+            }
+
+            [Fact]
+            public void WithThrownException_ReturnsAtLeastOneFrame()
+            {
+                var frames = UnityStackTraceParser.ParseException(ThrownException);
+
+                Assert.NotEmpty(frames);
+            }
+
+            [Fact]
+            public void EveryFrameContainsAllEightContractKeys()
+            {
+                var frames = UnityStackTraceParser.ParseException(ThrownException);
+
+                Assert.NotEmpty(frames);
+                foreach (var frame in frames)
+                {
+                    foreach (var key in ContractKeys)
+                    {
+                        Assert.True(
+                            frame.ContainsKey(key),
+                            $"frame missing contract key '{key}'. keys present: {string.Join(",", frame.Keys)}"
+                        );
+                    }
+                }
+            }
+
+            [Fact]
+            public void EveryFrameHasCustomPlatformAndCsharpLang()
+            {
+                var frames = UnityStackTraceParser.ParseException(ThrownException);
+
+                Assert.NotEmpty(frames);
+                foreach (var frame in frames)
+                {
+                    Assert.Equal("custom", frame["platform"]);
+                    Assert.Equal("csharp", frame["lang"]);
+                }
+            }
+
+            [Fact]
+            public void WithFreshlyConstructedException_ReturnsEmptyListWithoutThrowing()
+            {
+                var ex = new InvalidOperationException("not thrown");
+
+                List<Dictionary<string, object>> frames = null;
+                var thrown = Record.Exception(
+                    () => frames = UnityStackTraceParser.ParseException(ex)
+                );
+
+                Assert.Null(thrown);
+                Assert.Empty(frames);
+            }
+
+            [Fact]
+            public void FunctionFieldIsPopulatedForThrownFrame()
+            {
+                var frames = UnityStackTraceParser.ParseException(ThrownException);
+
+                Assert.NotEmpty(frames);
+                var function = frames[0]["function"] as string;
+                Assert.False(string.IsNullOrEmpty(function), "expected non-empty function name");
+            }
+        }
+    }
+}

--- a/tests/PostHog.Unity.Tests/UnityStackTraceParserTests.cs
+++ b/tests/PostHog.Unity.Tests/UnityStackTraceParserTests.cs
@@ -143,7 +143,8 @@ namespace PostHogUnity.Tests
             [Fact]
             public void WithCrLfLineEndings_ToleratesTrailingCarriageReturn()
             {
-                var trace = "A.B:First () (at Assets/A.cs:1)\r\nA.B:Second () (at Assets/B.cs:2)\r\n";
+                var trace =
+                    "A.B:First () (at Assets/A.cs:1)\r\nA.B:Second () (at Assets/B.cs:2)\r\n";
 
                 var frames = UnityStackTraceParser.Parse(trace);
 
@@ -157,7 +158,8 @@ namespace PostHogUnity.Tests
             [Fact]
             public void WithBlankLinesBetweenFrames_SkipsThem()
             {
-                var trace = "\nA.B:First () (at Assets/A.cs:1)\n\n\nA.B:Second () (at Assets/A.cs:2)\n";
+                var trace =
+                    "\nA.B:First () (at Assets/A.cs:1)\n\n\nA.B:Second () (at Assets/A.cs:2)\n";
 
                 var frames = UnityStackTraceParser.Parse(trace);
 
@@ -316,8 +318,8 @@ namespace PostHogUnity.Tests
                 var ex = new InvalidOperationException("not thrown");
 
                 List<Dictionary<string, object>> frames = null;
-                var thrown = Record.Exception(
-                    () => frames = UnityStackTraceParser.ParseException(ex)
+                var thrown = Record.Exception(() =>
+                    frames = UnityStackTraceParser.ParseException(ex)
                 );
 
                 Assert.Null(thrown);

--- a/tests/PostHog.Unity.Tests/WebGLExceptionIntegrationTests.cs
+++ b/tests/PostHog.Unity.Tests/WebGLExceptionIntegrationTests.cs
@@ -1,0 +1,237 @@
+using System.Reflection;
+using PostHogUnity.ErrorTracking;
+using UnityEngine;
+
+namespace PostHogUnity.Tests
+{
+    /// <summary>
+    /// Characterization tests for <see cref="WebGLExceptionIntegration"/>.
+    ///
+    /// Notes on the test seam (limitations of the Unity3D.SDK stub package):
+    ///   * <c>Application.logMessageReceived += …</c> and <c>-= …</c> route through
+    ///     the stub's <c>add_logMessageReceived</c> / <c>remove_logMessageReceived</c>
+    ///     accessors, which call into native code (ECall) and throw
+    ///     <c>SecurityException</c> in this test host. That means we cannot
+    ///     directly exercise <see cref="WebGLExceptionIntegration.Register"/> or
+    ///     <see cref="WebGLExceptionIntegration.Unregister"/> as a black box —
+    ///     those tests are <c>Skip</c>ped below with the reason recorded.
+    ///   * We can, however, exercise the private <c>HandleLogMessage</c>
+    ///     handler — the one piece of logic with branching: <c>LogType</c>
+    ///     filtering, "[PostHog]" prefix filtering, and try/catch around the
+    ///     callback. We do so via reflection, populating the private callback
+    ///     field directly. These tests are <em>structural</em>: if the rewrite
+    ///     renames the field/method, the reflection lookups below must be
+    ///     updated to point at whatever replaces them. The observable behavior
+    ///     they pin (filter rules + non-propagation) is still part of the public
+    ///     contract.
+    ///   * Internal logging paths reach <c>Debug.LogError</c>, which also calls
+    ///     into native code. As in <see cref="UnityExceptionIntegrationTests"/>,
+    ///     each test first swaps <c>Debug.unityLogger.logHandler</c> for a
+    ///     no-op test double so the native call never happens.
+    /// </summary>
+    [Collection("UnityGlobals")]
+    public class WebGLExceptionIntegrationTests
+    {
+        sealed class NullLogHandler : ILogHandler
+        {
+            public void LogException(Exception exception, UnityEngine.Object context) { }
+
+            public void LogFormat(
+                LogType logType,
+                UnityEngine.Object context,
+                string format,
+                params object[] args
+            ) { }
+        }
+
+        sealed class HandlerScope : IDisposable
+        {
+            readonly ILogHandler _original;
+            public HandlerScope(ILogHandler handler)
+            {
+                _original = Debug.unityLogger.logHandler;
+                Debug.unityLogger.logHandler = handler;
+            }
+            public void Dispose()
+            {
+                Debug.unityLogger.logHandler = _original;
+            }
+        }
+
+        const string CallbackFieldName = "_callback";
+        const string HandleLogMessageMethodName = "HandleLogMessage";
+
+        static readonly MethodInfo HandleLogMessageMethod =
+            typeof(WebGLExceptionIntegration).GetMethod(
+                HandleLogMessageMethodName,
+                BindingFlags.Instance | BindingFlags.NonPublic
+            ) ?? throw new InvalidOperationException(
+                $"Could not find {HandleLogMessageMethodName} on {typeof(WebGLExceptionIntegration).FullName}. "
+                + "If the rewrite renamed this private method, update the reflection lookup above to match."
+            );
+
+        static readonly FieldInfo CallbackField =
+            typeof(WebGLExceptionIntegration).GetField(
+                CallbackFieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic
+            ) ?? throw new InvalidOperationException(
+                $"Could not find {CallbackFieldName} on {typeof(WebGLExceptionIntegration).FullName}. "
+                + "If the rewrite renamed this field, update the reflection lookup above to match."
+            );
+
+        static void SetCallback(
+            WebGLExceptionIntegration integration,
+            Action<string, string> callback
+        )
+        {
+            CallbackField.SetValue(integration, callback);
+        }
+
+        static void RaiseLogMessage(
+            WebGLExceptionIntegration integration,
+            string condition,
+            string stackTrace,
+            LogType type
+        )
+        {
+            try
+            {
+                HandleLogMessageMethod.Invoke(
+                    integration,
+                    new object[] { condition, stackTrace, type }
+                );
+            }
+            catch (TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                // Surface the original exception so test assertions can reason about it.
+                throw tie.InnerException;
+            }
+        }
+
+        [Collection("UnityGlobals")]
+        public class TheRegisterMethod
+        {
+            [Fact(
+                Skip =
+                    "Register subscribes via Application.logMessageReceived += … which calls "
+                    + "into native code (ECall) in the Unity3D.SDK stub and throws SecurityException. "
+                    + "Cannot exercise the public Register contract from this test host."
+            )]
+            public void AfterRegister_ExceptionLogMessageInvokesCallback() { }
+        }
+
+        [Collection("UnityGlobals")]
+        public class TheUnregisterMethod
+        {
+            [Fact(
+                Skip =
+                    "Unregister unsubscribes via Application.logMessageReceived -= … which calls "
+                    + "into native code (ECall) in the Unity3D.SDK stub and throws SecurityException. "
+                    + "Cannot exercise the public Unregister contract from this test host."
+            )]
+            public void AfterUnregister_LogMessageDoesNotInvokeCallback() { }
+        }
+
+        [Collection("UnityGlobals")]
+        public class TheHandleLogMessageMethod
+        {
+            // Structural tests: these invoke the private HandleLogMessage method
+            // via reflection because Application.logMessageReceived cannot be raised
+            // through the stub's public event API. They still pin the public-contract
+            // behavior of the filter rules and non-propagation guarantee.
+
+            [Fact]
+            public void ExceptionType_WithNonEmptyConditionAndStackTrace_InvokesCallback()
+            {
+                using var scope = new HandlerScope(new NullLogHandler());
+
+                var integration = new WebGLExceptionIntegration();
+                string capturedCondition = null;
+                string capturedStack = null;
+                SetCallback(
+                    integration,
+                    (c, s) =>
+                    {
+                        capturedCondition = c;
+                        capturedStack = s;
+                    }
+                );
+
+                RaiseLogMessage(integration, "NullReferenceException", "stack", LogType.Exception);
+
+                Assert.Equal("NullReferenceException", capturedCondition);
+                Assert.Equal("stack", capturedStack);
+            }
+
+            [Theory]
+            [InlineData(LogType.Error)]
+            [InlineData(LogType.Warning)]
+            [InlineData(LogType.Log)]
+            [InlineData(LogType.Assert)]
+            public void NonExceptionType_DoesNotInvokeCallback(LogType type)
+            {
+                using var scope = new HandlerScope(new NullLogHandler());
+
+                var integration = new WebGLExceptionIntegration();
+                int invocations = 0;
+                SetCallback(integration, (_, __) => invocations++);
+
+                RaiseLogMessage(integration, "anything", "stack", type);
+
+                Assert.Equal(0, invocations);
+            }
+
+            [Fact]
+            public void ConditionStartingWithPostHogPrefix_IsFilteredOut()
+            {
+                using var scope = new HandlerScope(new NullLogHandler());
+
+                var integration = new WebGLExceptionIntegration();
+                int invocations = 0;
+                SetCallback(integration, (_, __) => invocations++);
+
+                RaiseLogMessage(
+                    integration,
+                    "[PostHog] An internal warning",
+                    "stack",
+                    LogType.Exception
+                );
+
+                Assert.Equal(0, invocations);
+            }
+
+            [Fact]
+            public void CallbackThatThrows_DoesNotPropagate()
+            {
+                using var scope = new HandlerScope(new NullLogHandler());
+
+                var integration = new WebGLExceptionIntegration();
+                SetCallback(
+                    integration,
+                    (_, __) => throw new ApplicationException("callback failed")
+                );
+
+                var thrown = Record.Exception(
+                    () => RaiseLogMessage(integration, "msg", "stack", LogType.Exception)
+                );
+
+                Assert.Null(thrown);
+            }
+
+            [Fact]
+            public void WithNoRegisteredCallback_DoesNothing()
+            {
+                using var scope = new HandlerScope(new NullLogHandler());
+
+                // No callback set — exercise the null-conditional branch.
+                var integration = new WebGLExceptionIntegration();
+
+                var thrown = Record.Exception(
+                    () => RaiseLogMessage(integration, "msg", "stack", LogType.Exception)
+                );
+
+                Assert.Null(thrown);
+            }
+        }
+    }
+}

--- a/tests/PostHog.Unity.Tests/WebGLExceptionIntegrationTests.cs
+++ b/tests/PostHog.Unity.Tests/WebGLExceptionIntegrationTests.cs
@@ -44,22 +44,6 @@ namespace PostHogUnity.Tests
             ) { }
         }
 
-        sealed class HandlerScope : IDisposable
-        {
-            readonly ILogHandler _original;
-
-            public HandlerScope(ILogHandler handler)
-            {
-                _original = Debug.unityLogger.logHandler;
-                Debug.unityLogger.logHandler = handler;
-            }
-
-            public void Dispose()
-            {
-                Debug.unityLogger.logHandler = _original;
-            }
-        }
-
         const string CallbackFieldName = "_callback";
         const string HandleLogMessageMethodName = "HandleLogMessage";
 
@@ -145,7 +129,7 @@ namespace PostHogUnity.Tests
             [Fact]
             public void ExceptionType_WithNonEmptyConditionAndStackTrace_InvokesCallback()
             {
-                using var scope = new HandlerScope(new NullLogHandler());
+                using var scope = new UnityHandlerScope(new NullLogHandler());
 
                 var integration = new WebGLExceptionIntegration();
                 string capturedCondition = null;
@@ -172,7 +156,7 @@ namespace PostHogUnity.Tests
             [InlineData(LogType.Assert)]
             public void NonExceptionType_DoesNotInvokeCallback(LogType type)
             {
-                using var scope = new HandlerScope(new NullLogHandler());
+                using var scope = new UnityHandlerScope(new NullLogHandler());
 
                 var integration = new WebGLExceptionIntegration();
                 int invocations = 0;
@@ -186,7 +170,7 @@ namespace PostHogUnity.Tests
             [Fact]
             public void ConditionStartingWithPostHogPrefix_IsFilteredOut()
             {
-                using var scope = new HandlerScope(new NullLogHandler());
+                using var scope = new UnityHandlerScope(new NullLogHandler());
 
                 var integration = new WebGLExceptionIntegration();
                 int invocations = 0;
@@ -205,7 +189,7 @@ namespace PostHogUnity.Tests
             [Fact]
             public void CallbackThatThrows_DoesNotPropagate()
             {
-                using var scope = new HandlerScope(new NullLogHandler());
+                using var scope = new UnityHandlerScope(new NullLogHandler());
 
                 var integration = new WebGLExceptionIntegration();
                 SetCallback(
@@ -223,7 +207,7 @@ namespace PostHogUnity.Tests
             [Fact]
             public void WithNoRegisteredCallback_DoesNothing()
             {
-                using var scope = new HandlerScope(new NullLogHandler());
+                using var scope = new UnityHandlerScope(new NullLogHandler());
 
                 // No callback set — exercise the null-conditional branch.
                 var integration = new WebGLExceptionIntegration();

--- a/tests/PostHog.Unity.Tests/WebGLExceptionIntegrationTests.cs
+++ b/tests/PostHog.Unity.Tests/WebGLExceptionIntegrationTests.cs
@@ -47,11 +47,13 @@ namespace PostHogUnity.Tests
         sealed class HandlerScope : IDisposable
         {
             readonly ILogHandler _original;
+
             public HandlerScope(ILogHandler handler)
             {
                 _original = Debug.unityLogger.logHandler;
                 Debug.unityLogger.logHandler = handler;
             }
+
             public void Dispose()
             {
                 Debug.unityLogger.logHandler = _original;
@@ -65,18 +67,20 @@ namespace PostHogUnity.Tests
             typeof(WebGLExceptionIntegration).GetMethod(
                 HandleLogMessageMethodName,
                 BindingFlags.Instance | BindingFlags.NonPublic
-            ) ?? throw new InvalidOperationException(
+            )
+            ?? throw new InvalidOperationException(
                 $"Could not find {HandleLogMessageMethodName} on {typeof(WebGLExceptionIntegration).FullName}. "
-                + "If the rewrite renamed this private method, update the reflection lookup above to match."
+                    + "If the rewrite renamed this private method, update the reflection lookup above to match."
             );
 
         static readonly FieldInfo CallbackField =
             typeof(WebGLExceptionIntegration).GetField(
                 CallbackFieldName,
                 BindingFlags.Instance | BindingFlags.NonPublic
-            ) ?? throw new InvalidOperationException(
+            )
+            ?? throw new InvalidOperationException(
                 $"Could not find {CallbackFieldName} on {typeof(WebGLExceptionIntegration).FullName}. "
-                + "If the rewrite renamed this field, update the reflection lookup above to match."
+                    + "If the rewrite renamed this field, update the reflection lookup above to match."
             );
 
         static void SetCallback(
@@ -112,8 +116,7 @@ namespace PostHogUnity.Tests
         public class TheRegisterMethod
         {
             [Fact(
-                Skip =
-                    "Register subscribes via Application.logMessageReceived += … which calls "
+                Skip = "Register subscribes via Application.logMessageReceived += … which calls "
                     + "into native code (ECall) in the Unity3D.SDK stub and throws SecurityException. "
                     + "Cannot exercise the public Register contract from this test host."
             )]
@@ -124,8 +127,7 @@ namespace PostHogUnity.Tests
         public class TheUnregisterMethod
         {
             [Fact(
-                Skip =
-                    "Unregister unsubscribes via Application.logMessageReceived -= … which calls "
+                Skip = "Unregister unsubscribes via Application.logMessageReceived -= … which calls "
                     + "into native code (ECall) in the Unity3D.SDK stub and throws SecurityException. "
                     + "Cannot exercise the public Unregister contract from this test host."
             )]
@@ -211,8 +213,8 @@ namespace PostHogUnity.Tests
                     (_, __) => throw new ApplicationException("callback failed")
                 );
 
-                var thrown = Record.Exception(
-                    () => RaiseLogMessage(integration, "msg", "stack", LogType.Exception)
+                var thrown = Record.Exception(() =>
+                    RaiseLogMessage(integration, "msg", "stack", LogType.Exception)
                 );
 
                 Assert.Null(thrown);
@@ -226,8 +228,8 @@ namespace PostHogUnity.Tests
                 // No callback set — exercise the null-conditional branch.
                 var integration = new WebGLExceptionIntegration();
 
-                var thrown = Record.Exception(
-                    () => RaiseLogMessage(integration, "msg", "stack", LogType.Exception)
+                var thrown = Record.Exception(() =>
+                    RaiseLogMessage(integration, "msg", "stack", LogType.Exception)
                 );
 
                 Assert.Null(thrown);


### PR DESCRIPTION
## :bulb: Motivation and Context

The error tracking integration was harder to follow than the rest of the codebase: the parser split work across `ParseStackFrame`, `ParseFileLocation`, `StripZeroes`, `TryResolveFileNameForMono`, and `CreateBasicStackFrame` with subtly different semantics, and the IL2CPP placeholder detection relied on a `Replace("0","")` heuristic that was hard to reason about. The two log-source integrations had inconsistent field naming and lifecycle patterns. None of this code had unit tests.

The `mechanism.type` field in `$exception_list[].mechanism` also differed across PostHog SDKs: Unity sent `"unity.log"` / `"unity.LogException"` for unhandled cases, while posthog-dotnet, posthog-js, and posthog-python all send `"generic"`. The field isn't read by the backend fingerprinter or the frontend UI (only `mechanism.handled` and `mechanism.synthetic` are), so the per-source strings were dead metadata.

This change restructures the three integrations into smaller, named helpers and aligns the wire format with posthog-dotnet. Every stack frame now carries the same eight keys (`platform`, `lang`, `filename`, `abs_path`, `function`, `module`, `lineno`, `colno`) and `mechanism.type` is `"generic"` everywhere.

Behavior is preserved across the refactor: `Parse` still keeps unparseable lines as basic frames so diagnostic context stays in the captured stack, `ParseException` still falls back to text parsing when `StackTrace.GetFrames()` returns null on IL2CPP/AOT builds, the IL2CPP `<00…00>` placeholder still surfaces as empty strings instead of a misleading path, and the `.meta` GUIDs are unchanged so consumers don't see asset reimport churn on upgrade.

Extra motivation and context: As part of an early proof of concept, we incorporated code from another SDK without retaining the original copyright attribution. The implementation has since been substantially refactored and is no longer derived from that code. That said, both implementations rely on Unity’s APIs for reading stack trace metadata, so some structural similarities are expected.

## :green_heart: How did you test it?

Added three test files covering the rewritten code:

- `UnityStackTraceParserTests.cs` covers null/empty input, unparseable lines, malformed lines, Windows paths, IL2CPP placeholders with and without line numbers, multi-line traces, CRLF endings, blank lines, and the eight-key wire format contract for `ParseException`.
- `UnityExceptionIntegrationTests.cs` covers register/unregister lifecycle, double-register no-op, callback exception swallowing, forward-to-original-handler, and `LogFormat` not triggering the callback. Uses a `HandlerScope` helper to safely swap `Debug.unityLogger.logHandler` for a recording double.
- `WebGLExceptionIntegrationTests.cs` covers the `LogType.Exception` filter, `[PostHog]` prefix recursion guard, callback exception swallowing, and null-callback safety. Uses reflection on `HandleLogMessage` because the public `Application.logMessageReceived` event accessors route into native code and throw `SecurityException` in the test host.

`bin/test` reports 406 passed, 2 skipped (the two WebGL `Register`/`Unregister` cases documented as unreachable from the test host).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file