### PR TITLE
chore: update PostHog/.github pins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     name: Notify Slack - Approval Needed
     needs: check-changesets
     if: needs.check-changesets.outputs.has-changesets == 'true'
-    uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@b6cef416551ce8e557d57e1bb4f6766da7389b4e
+    uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@5fc4680761e8ac29a61b212756230eba0e276d8c
     with:
       slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
       slack_user_group_id: ${{ vars.GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID }}
@@ -69,7 +69,7 @@ jobs:
       - name: Notify Slack - Approved
         continue-on-error: true
         if: needs.notify-approval-needed.outputs.slack_ts != ''
-        uses: PostHog/.github/.github/actions/slack-thread-reply@b6cef416551ce8e557d57e1bb4f6766da7389b4e
+        uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -182,7 +182,7 @@ jobs:
       - name: Notify Slack - Failed
         continue-on-error: true
         if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
-        uses: PostHog/.github/.github/actions/slack-thread-reply@b6cef416551ce8e557d57e1bb4f6766da7389b4e
+        uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -222,7 +222,7 @@ jobs:
       - name: Notify Slack - Rejected
         if: steps.check-rejection.outputs.was_rejected == 'true'
         continue-on-error: true
-        uses: PostHog/.github/.github/actions/slack-thread-reply@b6cef416551ce8e557d57e1bb4f6766da7389b4e
+        uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -240,7 +240,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Notify Slack - Released
-        uses: PostHog/.github/.github/actions/slack-thread-reply@b6cef416551ce8e557d57e1bb4f6766da7389b4e
+        uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}


### PR DESCRIPTION
## :bulb: Motivation and Context

Some workflows referenced older pinned `PostHog/.github` revisions. One older revision of the shared release approval workflow still used tag-based nested actions (`actions/checkout@v6` and `PostHog/posthog-github-action@v1.1.1`), which violates the org policy requiring every action reference, including nested reusable workflow actions, to be pinned to a full-length commit SHA.

This updates all `PostHog/.github` reusable workflow/action references in this repository to the latest pinned `PostHog/.github` commit: `5fc4680761e8ac29a61b212756230eba0e276d8c`.

## :green_heart: How did you test it?

- Ran `git diff --check`
- Verified all `PostHog/.github` references in `.github` point to `5fc4680761e8ac29a61b212756230eba0e276d8c`
- Verified the latest `PostHog/.github` revision has no unpinned `uses:` references

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
