### PR TITLE
fix: no-op SDK setup without API key

### DIFF
--- a/.changeset/noop-empty-api-key.md
+++ b/.changeset/noop-empty-api-key.md
@@ -1,0 +1,5 @@
+---
+'com.posthog.unity': patch
+---
+
+Skip manual SDK setup instead of throwing when the configuration or API key is missing or blank.

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -72,7 +72,14 @@ namespace PostHogUnity
         {
             if (config == null)
             {
-                throw new ArgumentNullException(nameof(config));
+                PostHogLogger.Warning("PostHog SDK setup skipped: configuration is null.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(config.ApiKey))
+            {
+                PostHogLogger.Warning("PostHog SDK setup skipped: API key is not configured.");
+                return;
             }
 
             config.Validate();

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -119,15 +119,24 @@ namespace PostHogUnity
         {
             lock (Lock)
             {
-                if (_instance != null)
+                if (_instance == null)
                 {
-                    _instance.ShutdownInternal();
-                    Destroy(_instance.gameObject);
-                    _instance = null;
+                    _isInitialized = false;
+                    return;
                 }
+
+                ShutdownInitializedInstance();
                 _isInitialized = false;
                 PostHogLogger.Info("PostHog SDK shut down");
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ShutdownInitializedInstance()
+        {
+            _instance.ShutdownInternal();
+            Destroy(_instance.gameObject);
+            _instance = null;
         }
 
         void InitializeInternal(PostHogConfig config)

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using PostHogUnity.ErrorTracking;
 using PostHogUnity.SessionReplay;
@@ -83,7 +84,12 @@ namespace PostHogUnity
             }
 
             config.Validate();
+            SetupValidConfig(config);
+        }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void SetupValidConfig(PostHogConfig config)
+        {
             lock (Lock)
             {
                 if (_isInitialized)

--- a/com.posthog.unity/Runtime/Utilities/PostHogLogger.cs
+++ b/com.posthog.unity/Runtime/Utilities/PostHogLogger.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace PostHogUnity
@@ -18,7 +19,7 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Debug)
             {
-                UnityEngine.Debug.Log($"[PostHog] {message}");
+                LogSafely(() => UnityEngine.Debug.Log($"[PostHog] {message}"));
             }
         }
 
@@ -26,7 +27,7 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Info)
             {
-                UnityEngine.Debug.Log($"[PostHog] {message}");
+                LogSafely(() => UnityEngine.Debug.Log($"[PostHog] {message}"));
             }
         }
 
@@ -34,7 +35,7 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Warning)
             {
-                UnityEngine.Debug.LogWarning($"[PostHog] {message}");
+                LogSafely(() => UnityEngine.Debug.LogWarning($"[PostHog] {message}"));
             }
         }
 
@@ -42,7 +43,7 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Error)
             {
-                UnityEngine.Debug.LogError($"[PostHog] {message}");
+                LogSafely(() => UnityEngine.Debug.LogError($"[PostHog] {message}"));
             }
         }
 
@@ -50,7 +51,19 @@ namespace PostHogUnity
         {
             if (_logLevel <= PostHogLogLevel.Error)
             {
-                UnityEngine.Debug.LogError($"[PostHog] {message}: {ex}");
+                LogSafely(() => UnityEngine.Debug.LogError($"[PostHog] {message}: {ex}"));
+            }
+        }
+
+        static void LogSafely(Action log)
+        {
+            try
+            {
+                log();
+            }
+            catch
+            {
+                // Logging should never crash the SDK when Unity logging is unavailable.
             }
         }
     }

--- a/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
@@ -1,0 +1,47 @@
+using PostHogUnity;
+
+namespace PostHogUnity.Tests
+{
+    public class PostHogSDKTests
+    {
+        public class TheSetupMethod
+        {
+            [Fact]
+            public void WithNullConfig_DoesNotThrowAndDoesNotInitialize()
+            {
+                var exception = Record.Exception(() => PostHogSDK.Setup(null));
+
+                Assert.Null(exception);
+                Assert.False(PostHogSDK.IsInitialized);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("   ")]
+            public void WithMissingApiKey_DoesNotThrowAndDoesNotInitialize(string apiKey)
+            {
+                var config = new PostHogConfig { ApiKey = apiKey };
+
+                var exception = Record.Exception(() => PostHogSDK.Setup(config));
+
+                Assert.Null(exception);
+                Assert.False(PostHogSDK.IsInitialized);
+            }
+        }
+
+        public class ThePostHogSetupMethod
+        {
+            [Fact]
+            public void WithMissingApiKey_DoesNotThrowAndDoesNotInitialize()
+            {
+                var config = new PostHogConfig { ApiKey = "\t" };
+
+                var exception = Record.Exception(() => PostHog.Setup(config));
+
+                Assert.Null(exception);
+                Assert.False(PostHog.IsInitialized);
+            }
+        }
+    }
+}

--- a/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
@@ -66,5 +66,74 @@ namespace PostHogUnity.Tests
                 Assert.False(PostHog.IsInitialized);
             }
         }
+
+        [Collection("UnityGlobals")]
+        public class ThePublicApiMethods
+        {
+            [Fact]
+            public async Task AfterSkippedSetup_AreNoOps()
+            {
+                var exception = await Record.ExceptionAsync(async () =>
+                {
+                    PostHog.Setup(new PostHogConfig { ApiKey = "" });
+
+                    PostHog.Capture("test event");
+                    PostHog.Screen("Home");
+                    PostHog.CaptureException(new InvalidOperationException("test"));
+                    await PostHog.IdentifyAsync("user-id");
+                    await PostHog.IdentifyAsync(
+                        "user-id",
+                        new Dictionary<string, object> { ["email"] = "user@example.com" }
+                    );
+                    await PostHog.ResetAsync();
+                    PostHog.Alias("alias-id");
+                    PostHog.Group("organization", "org-id");
+                    PostHog.Register("plan", "free");
+                    PostHog.Unregister("plan");
+                    PostHog.Flush();
+                    PostHog.OptOut();
+                    PostHog.OptIn();
+                    await PostHog.ReloadFeatureFlagsAsync();
+                    PostHog.SetPersonPropertiesForFlags(
+                        new Dictionary<string, object> { ["email"] = "user@example.com" }
+                    );
+                    PostHog.ResetPersonPropertiesForFlags();
+                    PostHog.SetGroupPropertiesForFlags(
+                        "organization",
+                        new Dictionary<string, object> { ["name"] = "PostHog" }
+                    );
+                    PostHog.ResetGroupPropertiesForFlags();
+                    PostHog.ResetGroupPropertiesForFlags("organization");
+
+                    Action handler = () => { };
+                    PostHog.OnFeatureFlagsLoaded += handler;
+                    PostHog.OnFeatureFlagsLoaded -= handler;
+
+                    PostHogSDK.StartSessionReplay();
+                    PostHogSDK.StopSessionReplay();
+                    PostHogSDK.RecordNetworkRequest("GET", "https://example.com/api", 200, 123);
+                    PostHogSDK.Shutdown();
+                });
+
+                Assert.Null(exception);
+                Assert.False(PostHog.IsInitialized);
+                Assert.Null(PostHogSDK.Instance);
+            }
+
+            [Fact]
+            public void WhenNotInitialized_ReturnDefaultValues()
+            {
+                Assert.Null(PostHog.DistinctId);
+                Assert.True(PostHog.IsOptedOut);
+
+                var flag = PostHog.GetFeatureFlag("beta-feature");
+                Assert.False(flag.Value.HasValue);
+                Assert.False(flag.IsEnabled);
+
+                Assert.False(PostHog.IsFeatureEnabled("beta-feature"));
+                Assert.True(PostHog.IsFeatureEnabled("beta-feature", defaultValue: true));
+                Assert.False(PostHogSDK.IsSessionReplayActive);
+            }
+        }
     }
 }

--- a/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
@@ -1,14 +1,30 @@
 using PostHogUnity;
+using UnityEngine;
 
 namespace PostHogUnity.Tests
 {
     public class PostHogSDKTests
     {
+        sealed class NoopLogHandler : ILogHandler
+        {
+            public void LogException(Exception exception, UnityEngine.Object context) { }
+
+            public void LogFormat(
+                LogType logType,
+                UnityEngine.Object context,
+                string format,
+                params object[] args
+            ) { }
+        }
+
+        [Collection("UnityGlobals")]
         public class TheSetupMethod
         {
             [Fact]
             public void WithNullConfig_DoesNotThrowAndDoesNotInitialize()
             {
+                using var scope = new UnityHandlerScope(new NoopLogHandler());
+
                 var exception = Record.Exception(() => PostHogSDK.Setup(null));
 
                 Assert.Null(exception);
@@ -21,6 +37,7 @@ namespace PostHogUnity.Tests
             [InlineData("   ")]
             public void WithMissingApiKey_DoesNotThrowAndDoesNotInitialize(string apiKey)
             {
+                using var scope = new UnityHandlerScope(new NoopLogHandler());
                 var config = new PostHogConfig { ApiKey = apiKey };
 
                 var exception = Record.Exception(() => PostHogSDK.Setup(config));
@@ -30,12 +47,18 @@ namespace PostHogUnity.Tests
             }
         }
 
+        [Collection("UnityGlobals")]
         public class ThePostHogSetupMethod
         {
-            [Fact]
-            public void WithMissingApiKey_DoesNotThrowAndDoesNotInitialize()
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("   ")]
+            [InlineData("\t")]
+            public void WithMissingApiKey_DoesNotThrowAndDoesNotInitialize(string apiKey)
             {
-                var config = new PostHogConfig { ApiKey = "\t" };
+                using var scope = new UnityHandlerScope(new NoopLogHandler());
+                var config = new PostHogConfig { ApiKey = apiKey };
 
                 var exception = Record.Exception(() => PostHog.Setup(config));
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

SDK setup should be safe to call when PostHog is not configured. This changes setup with a null config or missing/blank API key to no-op with a warning instead of throwing, leaving the SDK uninitialized.

Public APIs now have regression coverage to ensure calls after skipped setup remain no-ops and return safe defaults instead of throwing. Unity-dependent setup/shutdown work is split out so invalid config and uninitialized shutdown can return before Unity ECall code is JIT-compiled in the .NET test host, and SDK logging is guarded so logging failures do not crash the SDK.

## :green_heart: How did you test it?

- Added unit tests for null config and missing/blank API keys through both `PostHogSDK.Setup` and the `PostHog.Setup` facade.
- Added unit tests that call public APIs after skipped setup and assert they no-op / return safe defaults.
- `DOTNET_ROOT="$HOME/.dotnet" PATH="$HOME/.dotnet:$PATH" ./bin/test`
- `./bin/fmt --check`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
