### PR TITLE
docs: improve API XML documentation

### DIFF
--- a/com.posthog.unity/Runtime/FeatureFlags/PostHogFeatureFlag.cs
+++ b/com.posthog.unity/Runtime/FeatureFlags/PostHogFeatureFlag.cs
@@ -91,8 +91,14 @@ namespace PostHogUnity
         /// <summary>
         /// Implicit conversion to bool.
         /// </summary>
+        /// <param name="value">The feature flag value to evaluate.</param>
+        /// <returns>True when the value is enabled.</returns>
         public static implicit operator bool(FlagValue value) => value.IsEnabled;
 
+        /// <summary>
+        /// Returns the string representation of the flag value.
+        /// </summary>
+        /// <returns>The boolean value, string variant, or "null" when no value exists.</returns>
         public override string ToString()
         {
             if (!_hasValue)
@@ -156,7 +162,7 @@ namespace PostHogUnity
         /// <summary>
         /// Gets the payload deserialized to a specific type using Unity's JsonUtility.
         /// </summary>
-        /// <typeparam name="T">The type to deserialize to (must have [Serializable] attribute)</typeparam>
+        /// <typeparam name="T">The type to deserialize to. Complex types must have the [Serializable] attribute and public fields.</typeparam>
         /// <param name="defaultValue">Default value if deserialization fails</param>
         /// <returns>The deserialized payload or default</returns>
         public T GetPayload<T>(T defaultValue = default)
@@ -208,11 +214,17 @@ namespace PostHogUnity
         /// <summary>
         /// Implicit conversion to bool for easy conditional checks.
         /// </summary>
+        /// <param name="flag">The feature flag to evaluate.</param>
+        /// <returns>True when the flag is enabled.</returns>
         public static implicit operator bool(PostHogFeatureFlag flag)
         {
             return flag?.IsEnabled ?? false;
         }
 
+        /// <summary>
+        /// Returns the string representation of the feature flag.
+        /// </summary>
+        /// <returns>A string containing the flag key and value.</returns>
         public override string ToString()
         {
             return $"PostHogFeatureFlag({_key}: {_value})";

--- a/com.posthog.unity/Runtime/Models/BatchPayload.cs
+++ b/com.posthog.unity/Runtime/Models/BatchPayload.cs
@@ -24,12 +24,20 @@ namespace PostHogUnity
         /// </summary>
         public string SentAt { get; set; }
 
+        /// <summary>
+        /// Creates an empty batch payload with the current timestamp.
+        /// </summary>
         public BatchPayload()
         {
             Batch = new List<PostHogEvent>();
             SentAt = DateTime.UtcNow.ToString("o");
         }
 
+        /// <summary>
+        /// Creates a batch payload for the specified API key and events.
+        /// </summary>
+        /// <param name="apiKey">The PostHog project API key.</param>
+        /// <param name="events">Events to include in the batch.</param>
         public BatchPayload(string apiKey, List<PostHogEvent> events)
             : this()
         {

--- a/com.posthog.unity/Runtime/Models/PostHogEvent.cs
+++ b/com.posthog.unity/Runtime/Models/PostHogEvent.cs
@@ -47,6 +47,8 @@ namespace PostHogUnity
         /// <summary>
         /// Creates a new PostHog event with the specified name and distinct ID.
         /// </summary>
+        /// <param name="eventName">Name of the event.</param>
+        /// <param name="distinctId">Distinct ID associated with the event.</param>
         public PostHogEvent(string eventName, string distinctId)
             : this()
         {
@@ -57,6 +59,9 @@ namespace PostHogUnity
         /// <summary>
         /// Creates a new PostHog event with the specified name, distinct ID, and properties.
         /// </summary>
+        /// <param name="eventName">Name of the event.</param>
+        /// <param name="distinctId">Distinct ID associated with the event.</param>
+        /// <param name="properties">Event properties to copy into the event.</param>
         public PostHogEvent(
             string eventName,
             string distinctId,

--- a/com.posthog.unity/Runtime/PostHog.cs
+++ b/com.posthog.unity/Runtime/PostHog.cs
@@ -13,6 +13,8 @@ namespace PostHogUnity
         /// <summary>
         /// Initializes the PostHog SDK with the given configuration.
         /// </summary>
+        /// <param name="config">Configuration containing the project API key, host, and SDK options.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when numeric configuration values are outside their allowed ranges.</exception>
         public static void Setup(PostHogConfig config) => PostHogSDK.Setup(config);
 
         /// <summary>
@@ -38,6 +40,8 @@ namespace PostHogUnity
         /// <summary>
         /// Captures an event with the given name and optional properties.
         /// </summary>
+        /// <param name="eventName">Name of the event to capture.</param>
+        /// <param name="properties">Optional event properties to send with the event.</param>
         public static void Capture(
             string eventName,
             Dictionary<string, object> properties = null
@@ -46,6 +50,8 @@ namespace PostHogUnity
         /// <summary>
         /// Captures a screen view event.
         /// </summary>
+        /// <param name="screenName">Name of the screen or scene being viewed.</param>
+        /// <param name="properties">Optional properties to include with the screen view event.</param>
         public static void Screen(
             string screenName,
             Dictionary<string, object> properties = null
@@ -94,11 +100,15 @@ namespace PostHogUnity
         /// <summary>
         /// Creates an alias linking the current distinct ID to another ID.
         /// </summary>
+        /// <param name="alias">The alternate distinct ID to associate with the current user.</param>
         public static void Alias(string alias) => PostHogSDK.Alias(alias);
 
         /// <summary>
         /// Associates the current user with a group.
         /// </summary>
+        /// <param name="groupType">Type of group, such as "company" or "team".</param>
+        /// <param name="groupKey">Unique identifier for the group.</param>
+        /// <param name="groupProperties">Optional properties to set on the group profile.</param>
         public static void Group(
             string groupType,
             string groupKey,
@@ -108,11 +118,14 @@ namespace PostHogUnity
         /// <summary>
         /// Registers a super property that will be sent with every event.
         /// </summary>
+        /// <param name="key">Property name to register.</param>
+        /// <param name="value">Property value to send with future events.</param>
         public static void Register(string key, object value) => PostHogSDK.Register(key, value);
 
         /// <summary>
         /// Unregisters a super property.
         /// </summary>
+        /// <param name="key">Property name to remove.</param>
         public static void Unregister(string key) => PostHogSDK.Unregister(key);
 
         /// <summary>

--- a/com.posthog.unity/Runtime/PostHogConfig.cs
+++ b/com.posthog.unity/Runtime/PostHogConfig.cs
@@ -24,26 +24,26 @@ namespace PostHogUnity
 
         /// <summary>
         /// Number of events to queue before triggering a flush.
-        /// Defaults to 20.
+        /// Must be at least 1. Defaults to 20.
         /// </summary>
         public int FlushAt { get; set; } = 20;
 
         /// <summary>
         /// Interval in seconds between automatic flush attempts.
-        /// Defaults to 30 seconds.
+        /// Must be at least 1. Defaults to 30 seconds.
         /// </summary>
         public int FlushIntervalSeconds { get; set; } = 30;
 
         /// <summary>
         /// Maximum number of events to store in the queue.
         /// Oldest events are dropped when this limit is exceeded.
-        /// Defaults to 1000.
+        /// Must be at least 1. Defaults to 1000.
         /// </summary>
         public int MaxQueueSize { get; set; } = 1000;
 
         /// <summary>
         /// Maximum number of events to send in a single batch request.
-        /// Defaults to 50.
+        /// Must be at least 1. Defaults to 50.
         /// </summary>
         public int MaxBatchSize { get; set; } = 50;
 
@@ -116,10 +116,12 @@ namespace PostHogUnity
         public float FlushOnQuitTimeoutSeconds { get; set; } = 3f;
 
         /// <summary>
-        /// Custom JSON deserializer for feature flag payloads.
-        /// If not set, Unity's JsonUtility is used (which requires [Serializable] and public fields).
-        /// Set this to use a library like Newtonsoft.Json for better compatibility.
+        /// Optional delegate for custom feature flag payload JSON deserialization.
         /// </summary>
+        /// <remarks>
+        /// The delegate receives payload JSON and a target Type, and should return an instance
+        /// of that type. PostHogFeatureFlag.GetPayload&lt;T&gt; uses Unity's JsonUtility.
+        /// </remarks>
         /// <example>
         /// // Using Newtonsoft.Json
         /// config.PayloadDeserializer = (json, type) => JsonConvert.DeserializeObject(json, type);
@@ -136,8 +138,7 @@ namespace PostHogUnity
 
         /// <summary>
         /// Minimum time in milliseconds between capturing exceptions.
-        /// Set to 0 to disable debouncing.
-        /// Defaults to 1000ms (1 second).
+        /// Set to 0 to disable debouncing. Defaults to 1000ms (1 second).
         /// </summary>
         public int ExceptionDebounceIntervalMs { get; set; } = 1000;
 
@@ -160,15 +161,17 @@ namespace PostHogUnity
 
         /// <summary>
         /// Configuration options for session replay.
-        /// Only used when SessionReplay is true.
+        /// Only used when SessionReplay is true. Defaults to a new PostHogSessionReplayConfig.
         /// </summary>
         public PostHogSessionReplayConfig SessionReplayConfig { get; set; } = new();
 
         #endregion
 
         /// <summary>
-        /// Validates the configuration and throws if invalid.
+        /// Validates the configuration and normalizes empty hosts to the default host.
         /// </summary>
+        /// <exception cref="ArgumentException">Thrown when ApiKey is missing.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when queue, batch, flush, or enabled session replay values are outside their allowed ranges.</exception>
         public void Validate()
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
@@ -232,7 +235,7 @@ namespace PostHogUnity
         Always,
 
         /// <summary>
-        /// Only create/update person profiles on identify(), alias(), and group() calls.
+        /// Only create/update person profiles for identified users after IdentifyAsync is called.
         /// This is the default and recommended setting.
         /// </summary>
         IdentifiedOnly,

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -69,6 +69,8 @@ namespace PostHogUnity
         /// <summary>
         /// Initializes the PostHog SDK with the given configuration.
         /// </summary>
+        /// <param name="config">Configuration containing the project API key, host, and SDK options.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when numeric configuration values are outside their allowed ranges.</exception>
         public static void Setup(PostHogConfig config)
         {
             if (config == null)
@@ -294,6 +296,8 @@ namespace PostHogUnity
         /// <summary>
         /// Captures an event with the given name and optional properties.
         /// </summary>
+        /// <param name="eventName">Name of the event to capture.</param>
+        /// <param name="properties">Optional event properties to send with the event.</param>
         public static void Capture(string eventName, Dictionary<string, object> properties = null)
         {
             if (!EnsureInitialized())
@@ -304,6 +308,8 @@ namespace PostHogUnity
         /// <summary>
         /// Captures a screen view event.
         /// </summary>
+        /// <param name="screenName">Name of the screen or scene being viewed.</param>
+        /// <param name="properties">Optional properties to include with the screen view event.</param>
         public static void Screen(string screenName, Dictionary<string, object> properties = null)
         {
             if (!EnsureInitialized())
@@ -515,6 +521,7 @@ namespace PostHogUnity
         /// <summary>
         /// Creates an alias linking the current distinct ID to another ID.
         /// </summary>
+        /// <param name="alias">The alternate distinct ID to associate with the current user.</param>
         public static void Alias(string alias)
         {
             if (!EnsureInitialized())
@@ -652,6 +659,9 @@ namespace PostHogUnity
         /// <summary>
         /// Associates the current user with a group.
         /// </summary>
+        /// <param name="groupType">Type of group, such as "company" or "team".</param>
+        /// <param name="groupKey">Unique identifier for the group.</param>
+        /// <param name="groupProperties">Optional properties to set on the group profile.</param>
         public static void Group(
             string groupType,
             string groupKey,
@@ -693,6 +703,8 @@ namespace PostHogUnity
         /// <summary>
         /// Registers a super property that will be sent with every event.
         /// </summary>
+        /// <param name="key">Property name to register.</param>
+        /// <param name="value">Property value to send with future events.</param>
         public static void Register(string key, object value)
         {
             if (!EnsureInitialized())
@@ -703,6 +715,7 @@ namespace PostHogUnity
         /// <summary>
         /// Unregisters a super property.
         /// </summary>
+        /// <param name="key">Property name to remove.</param>
         public static void Unregister(string key)
         {
             if (!EnsureInitialized())
@@ -1009,6 +1022,7 @@ namespace PostHogUnity
         /// <summary>
         /// Returns true if session replay is currently active.
         /// </summary>
+        /// <remarks>Returns false when the SDK is not initialized or session replay is not running.</remarks>
         public static bool IsSessionReplayActive
         {
             get
@@ -1022,6 +1036,7 @@ namespace PostHogUnity
         /// <summary>
         /// Starts session replay if it was configured but not yet started.
         /// </summary>
+        /// <remarks>No effect when the SDK is not initialized, session replay is not configured, or replay is already running.</remarks>
         public static void StartSessionReplay()
         {
             if (!EnsureInitialized())
@@ -1032,6 +1047,7 @@ namespace PostHogUnity
         /// <summary>
         /// Stops session replay.
         /// </summary>
+        /// <remarks>No effect when the SDK is not initialized or session replay is not running.</remarks>
         public static void StopSessionReplay()
         {
             if (!EnsureInitialized())
@@ -1043,6 +1059,7 @@ namespace PostHogUnity
         /// Records a network request for session replay telemetry.
         /// Call this after each HTTP request completes to include it in the replay.
         /// </summary>
+        /// <remarks>No effect unless session replay network telemetry is active.</remarks>
         /// <param name="method">HTTP method (GET, POST, etc.)</param>
         /// <param name="url">Request URL</param>
         /// <param name="statusCode">HTTP response status code</param>

--- a/com.posthog.unity/Runtime/SessionReplay/Models/RRWebModels.cs
+++ b/com.posthog.unity/Runtime/SessionReplay/Models/RRWebModels.cs
@@ -54,10 +54,29 @@ namespace PostHogUnity.SessionReplay
     /// </summary>
     public static class RRWireframeType
     {
+        /// <summary>
+        /// Screenshot wireframe element.
+        /// </summary>
         public const string Screenshot = "screenshot";
+
+        /// <summary>
+        /// Text wireframe element.
+        /// </summary>
         public const string Text = "text";
+
+        /// <summary>
+        /// Image wireframe element.
+        /// </summary>
         public const string Image = "image";
+
+        /// <summary>
+        /// Rectangle wireframe element.
+        /// </summary>
         public const string Rectangle = "div";
+
+        /// <summary>
+        /// Input wireframe element.
+        /// </summary>
         public const string Input = "input";
     }
 
@@ -81,6 +100,9 @@ namespace PostHogUnity.SessionReplay
         /// </summary>
         public long Timestamp { get; set; }
 
+        /// <summary>
+        /// Creates an empty RRWeb event.
+        /// </summary>
         public RREvent()
         {
             Data = new Dictionary<string, object>();
@@ -89,6 +111,11 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Creates a meta event with screen dimensions.
         /// </summary>
+        /// <param name="width">Screen width in pixels.</param>
+        /// <param name="height">Screen height in pixels.</param>
+        /// <param name="screenName">Current screen name, or null for an empty value.</param>
+        /// <param name="timestamp">Unix timestamp in milliseconds.</param>
+        /// <returns>A meta RRWeb event.</returns>
         public static RREvent CreateMeta(int width, int height, string screenName, long timestamp)
         {
             return new RREvent
@@ -107,6 +134,9 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Creates a full snapshot event with a screenshot wireframe.
         /// </summary>
+        /// <param name="wireframe">Wireframe element to include in the snapshot.</param>
+        /// <param name="timestamp">Unix timestamp in milliseconds.</param>
+        /// <returns>A full snapshot RRWeb event.</returns>
         public static RREvent CreateFullSnapshot(RRWireframe wireframe, long timestamp)
         {
             var wireframes = new List<Dictionary<string, object>> { wireframe.ToDictionary() };
@@ -130,6 +160,11 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Creates a touch/pointer event.
         /// </summary>
+        /// <param name="x">Pointer X coordinate in pixels.</param>
+        /// <param name="y">Pointer Y coordinate in pixels.</param>
+        /// <param name="touchType">RRWeb touch type constant.</param>
+        /// <param name="timestamp">Unix timestamp in milliseconds.</param>
+        /// <returns>An incremental snapshot RRWeb event.</returns>
         public static RREvent CreatePointerEvent(float x, float y, int touchType, long timestamp)
         {
             return new RREvent
@@ -151,6 +186,9 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Creates a plugin data event for network telemetry.
         /// </summary>
+        /// <param name="requests">Network request samples to include.</param>
+        /// <param name="timestamp">Unix timestamp in milliseconds.</param>
+        /// <returns>A network telemetry plugin RRWeb event.</returns>
         public static RREvent CreateNetworkPlugin(List<NetworkSample> requests, long timestamp)
         {
             var requestDicts = new List<Dictionary<string, object>>();
@@ -174,6 +212,9 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Creates a plugin data event for console logs.
         /// </summary>
+        /// <param name="logs">Console log entries to include.</param>
+        /// <param name="timestamp">Unix timestamp in milliseconds.</param>
+        /// <returns>A console log plugin RRWeb event.</returns>
         public static RREvent CreateConsoleLogPlugin(List<LogEntry> logs, long timestamp)
         {
             var logDicts = new List<Dictionary<string, object>>();
@@ -197,6 +238,7 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Converts the event to a dictionary for JSON serialization.
         /// </summary>
+        /// <returns>A dictionary representation of the event.</returns>
         public Dictionary<string, object> ToDictionary()
         {
             return new Dictionary<string, object>
@@ -258,6 +300,10 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Creates a screenshot wireframe from base64 image data.
         /// </summary>
+        /// <param name="width">Scaled screenshot width in pixels.</param>
+        /// <param name="height">Scaled screenshot height in pixels.</param>
+        /// <param name="base64Data">Base64-encoded image data with data URL prefix.</param>
+        /// <returns>A screenshot wireframe element.</returns>
         public static RRWireframe CreateScreenshot(int width, int height, string base64Data)
         {
             return new RRWireframe
@@ -275,6 +321,7 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Converts the wireframe to a dictionary for JSON serialization.
         /// </summary>
+        /// <returns>A dictionary representation of the wireframe.</returns>
         public Dictionary<string, object> ToDictionary()
         {
             var dict = new Dictionary<string, object>
@@ -306,17 +353,45 @@ namespace PostHogUnity.SessionReplay
     /// </summary>
     public class RRStyle
     {
+        /// <summary>
+        /// Text color CSS value.
+        /// </summary>
         public string Color { get; set; }
+
+        /// <summary>
+        /// Background color CSS value.
+        /// </summary>
         public string BackgroundColor { get; set; }
+
+        /// <summary>
+        /// Border width in pixels.
+        /// </summary>
         public int? BorderWidth { get; set; }
+
+        /// <summary>
+        /// Border radius in pixels.
+        /// </summary>
         public int? BorderRadius { get; set; }
+
+        /// <summary>
+        /// Border color CSS value.
+        /// </summary>
         public string BorderColor { get; set; }
+
+        /// <summary>
+        /// Font size in pixels.
+        /// </summary>
         public int? FontSize { get; set; }
+
+        /// <summary>
+        /// Font family name.
+        /// </summary>
         public string FontFamily { get; set; }
 
         /// <summary>
         /// Converts the style to a dictionary for JSON serialization.
         /// </summary>
+        /// <returns>A dictionary representation of the style.</returns>
         public Dictionary<string, object> ToDictionary()
         {
             var dict = new Dictionary<string, object>();
@@ -388,6 +463,7 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Converts to dictionary for JSON serialization.
         /// </summary>
+        /// <returns>A dictionary representation of the network sample.</returns>
         public Dictionary<string, object> ToDictionary()
         {
             return new Dictionary<string, object>
@@ -432,6 +508,7 @@ namespace PostHogUnity.SessionReplay
         /// <summary>
         /// Converts to dictionary for JSON serialization.
         /// </summary>
+        /// <returns>A dictionary representation of the log entry.</returns>
         public Dictionary<string, object> ToDictionary()
         {
             var dict = new Dictionary<string, object>

--- a/com.posthog.unity/Runtime/SessionReplay/NetworkTelemetry.cs
+++ b/com.posthog.unity/Runtime/SessionReplay/NetworkTelemetry.cs
@@ -171,6 +171,11 @@ namespace PostHogUnity.SessionReplay
         /// Records a network request to the session replay telemetry.
         /// Call this after each HTTP request completes if you want it recorded in session replay.
         /// </summary>
+        /// <param name="method">HTTP method, such as GET or POST.</param>
+        /// <param name="url">Request URL.</param>
+        /// <param name="statusCode">HTTP response status code.</param>
+        /// <param name="durationMs">Request duration in milliseconds.</param>
+        /// <param name="responseSize">Response body size in bytes.</param>
         public static void RecordForReplay(
             string method,
             string url,

--- a/com.posthog.unity/Runtime/SessionReplay/PostHogSessionReplayConfig.cs
+++ b/com.posthog.unity/Runtime/SessionReplay/PostHogSessionReplayConfig.cs
@@ -16,7 +16,7 @@ namespace PostHogUnity.SessionReplay
         public float ThrottleDelaySeconds { get; set; } = 1.0f;
 
         /// <summary>
-        /// JPEG compression quality for screenshots (0-100).
+        /// JPEG compression quality for screenshots (1-100).
         /// Lower values reduce file size but decrease image quality.
         /// Defaults to 80 for good visual quality.
         /// </summary>
@@ -52,26 +52,27 @@ namespace PostHogUnity.SessionReplay
 
         /// <summary>
         /// Maximum number of replay events to queue before flushing.
-        /// Defaults to 20.
+        /// Must be at least 1. Defaults to 20.
         /// </summary>
         public int FlushAt { get; set; } = 20;
 
         /// <summary>
         /// Interval in seconds between automatic replay flushes.
-        /// Defaults to 30 seconds.
+        /// Must be at least 1. Defaults to 30 seconds.
         /// </summary>
         public int FlushIntervalSeconds { get; set; } = 30;
 
         /// <summary>
         /// Maximum number of replay events to store in the queue.
         /// Oldest events are dropped when this limit is exceeded.
-        /// Defaults to 100.
+        /// Must be at least 1. Defaults to 100.
         /// </summary>
         public int MaxQueueSize { get; set; } = 100;
 
         /// <summary>
-        /// Validates the configuration and throws if invalid.
+        /// Validates the configuration values.
         /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when screenshot, throttle, queue, or flush values are outside their allowed ranges.</exception>
         public void Validate()
         {
             if (ThrottleDelaySeconds < 0.1f)

--- a/com.posthog.unity/Runtime/Storage/FileStorageProvider.cs
+++ b/com.posthog.unity/Runtime/Storage/FileStorageProvider.cs
@@ -22,6 +22,7 @@ namespace PostHogUnity
         // Track pending writes so we can wait for them on shutdown
         readonly ConcurrentDictionary<string, Task> _pendingWrites = new();
 
+        /// <inheritdoc />
         public void Initialize(string basePath)
         {
             _queuePath = Path.Combine(basePath, "queue");
@@ -70,6 +71,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public void SaveEvent(string id, string jsonData)
         {
             // Add to index immediately so the event is counted
@@ -108,6 +110,7 @@ namespace PostHogUnity
             _pendingWrites[id] = writeTask;
         }
 
+        /// <inheritdoc />
         public string LoadEvent(string id)
         {
             // Wait for any pending write for this event to complete
@@ -145,6 +148,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public void DeleteEvent(string id)
         {
             // Wait for any pending write for this event to complete before deleting
@@ -176,6 +180,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<string> GetEventIds()
         {
             lock (_lock)
@@ -184,6 +189,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public int GetEventCount()
         {
             lock (_lock)
@@ -192,6 +198,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public void Clear()
         {
             // Wait for all pending writes before clearing
@@ -245,6 +252,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public void SaveState(string key, string jsonData)
         {
             try
@@ -259,6 +267,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public string LoadState(string key)
         {
             try
@@ -277,6 +286,7 @@ namespace PostHogUnity
             return null;
         }
 
+        /// <inheritdoc />
         public void DeleteState(string key)
         {
             try

--- a/com.posthog.unity/Runtime/Storage/IStorageProvider.cs
+++ b/com.posthog.unity/Runtime/Storage/IStorageProvider.cs
@@ -10,6 +10,7 @@ namespace PostHogUnity
         /// <summary>
         /// Initializes the storage provider with the given base path.
         /// </summary>
+        /// <param name="basePath">Base directory or platform-specific location for persisted SDK data.</param>
         void Initialize(string basePath);
 
         /// <summary>

--- a/com.posthog.unity/Runtime/Storage/PlayerPrefsStorageProvider.cs
+++ b/com.posthog.unity/Runtime/Storage/PlayerPrefsStorageProvider.cs
@@ -19,6 +19,7 @@ namespace PostHogUnity
         readonly object _lock = new();
         List<string> _eventIds;
 
+        /// <inheritdoc />
         public void Initialize(string basePath)
         {
             // basePath is ignored for PlayerPrefs
@@ -92,6 +93,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public void SaveEvent(string id, string jsonData)
         {
             lock (_lock)
@@ -125,6 +127,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public string LoadEvent(string id)
         {
             lock (_lock)
@@ -148,6 +151,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public void DeleteEvent(string id)
         {
             lock (_lock)
@@ -166,6 +170,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public IReadOnlyList<string> GetEventIds()
         {
             lock (_lock)
@@ -174,6 +179,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public int GetEventCount()
         {
             lock (_lock)
@@ -182,6 +188,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public void Clear()
         {
             lock (_lock)
@@ -205,6 +212,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public void SaveState(string key, string jsonData)
         {
             try
@@ -219,6 +227,7 @@ namespace PostHogUnity
             }
         }
 
+        /// <inheritdoc />
         public string LoadState(string key)
         {
             try
@@ -237,6 +246,7 @@ namespace PostHogUnity
             return null;
         }
 
+        /// <inheritdoc />
         public void DeleteState(string key)
         {
             try

--- a/com.posthog.unity/Runtime/Utilities/PostHogJson.cs
+++ b/com.posthog.unity/Runtime/Utilities/PostHogJson.cs
@@ -19,6 +19,7 @@ namespace PostHogUnity
         /// <summary>
         /// Creates a new PostHogJson wrapper around a value.
         /// </summary>
+        /// <param name="value">The raw JSON-compatible value to wrap.</param>
         public PostHogJson(object value)
         {
             _value = value;
@@ -68,7 +69,8 @@ namespace PostHogUnity
         /// <summary>
         /// Gets the value as a string.
         /// </summary>
-        /// <param name="defaultValue">Default value if null or not a string</param>
+        /// <param name="defaultValue">Default value if null</param>
+        /// <returns>The string value, the value's ToString() result, or the default value.</returns>
         public string GetString(string defaultValue = null)
         {
             if (_value is string s)
@@ -80,6 +82,7 @@ namespace PostHogUnity
         /// Gets the value as an integer.
         /// </summary>
         /// <param name="defaultValue">Default value if null or not convertible</param>
+        /// <returns>The integer value or the default value.</returns>
         public int GetInt(int defaultValue = 0)
         {
             try
@@ -105,6 +108,7 @@ namespace PostHogUnity
         /// Gets the value as a long.
         /// </summary>
         /// <param name="defaultValue">Default value if null or not convertible</param>
+        /// <returns>The long value or the default value.</returns>
         public long GetLong(long defaultValue = 0)
         {
             try
@@ -130,6 +134,7 @@ namespace PostHogUnity
         /// Gets the value as a float.
         /// </summary>
         /// <param name="defaultValue">Default value if null or not convertible</param>
+        /// <returns>The float value or the default value.</returns>
         public float GetFloat(float defaultValue = 0f)
         {
             try
@@ -155,6 +160,7 @@ namespace PostHogUnity
         /// Gets the value as a double.
         /// </summary>
         /// <param name="defaultValue">Default value if null or not convertible</param>
+        /// <returns>The double value or the default value.</returns>
         public double GetDouble(double defaultValue = 0.0)
         {
             try
@@ -180,6 +186,8 @@ namespace PostHogUnity
         /// Gets the value as a boolean.
         /// </summary>
         /// <param name="defaultValue">Default value if null or not convertible</param>
+        /// <returns>The boolean value or the default value.</returns>
+        /// <remarks>Non-empty strings and non-zero integers are treated as true.</remarks>
         public bool GetBool(bool defaultValue = false)
         {
             return _value switch
@@ -202,6 +210,7 @@ namespace PostHogUnity
         /// Returns PostHogJson.Null if the key doesn't exist or this isn't an object.
         /// </summary>
         /// <param name="key">The property key</param>
+        /// <returns>The nested value, or PostHogJson.Null when unavailable.</returns>
         public PostHogJson this[string key]
         {
             get
@@ -219,6 +228,7 @@ namespace PostHogUnity
         /// Returns PostHogJson.Null if the index is out of bounds or this isn't an array.
         /// </summary>
         /// <param name="index">The array index</param>
+        /// <returns>The indexed value, or PostHogJson.Null when unavailable.</returns>
         public PostHogJson this[int index]
         {
             get
@@ -240,6 +250,7 @@ namespace PostHogUnity
         /// Returns PostHogJson.Null if any part of the path doesn't exist.
         /// </summary>
         /// <param name="path">Dot-separated path to the value</param>
+        /// <returns>The nested value, this instance for an empty path, or PostHogJson.Null.</returns>
         public PostHogJson GetPath(string path)
         {
             if (string.IsNullOrEmpty(path))
@@ -271,6 +282,7 @@ namespace PostHogUnity
         /// Checks if this object contains a key.
         /// </summary>
         /// <param name="key">The key to check</param>
+        /// <returns>True if this value is an object and contains the key.</returns>
         public bool ContainsKey(string key)
         {
             return _value is Dictionary<string, object> dict && dict.ContainsKey(key);
@@ -318,6 +330,7 @@ namespace PostHogUnity
         /// Converts to a dictionary of PostHogJson values (for JSON objects).
         /// Returns null if this isn't an object.
         /// </summary>
+        /// <returns>A dictionary of wrapped values, or null when this value is not an object.</returns>
         public Dictionary<string, PostHogJson> AsDictionary()
         {
             if (_value is Dictionary<string, object> dict)
@@ -336,6 +349,7 @@ namespace PostHogUnity
         /// Converts to a list of PostHogJson values (for JSON arrays).
         /// Returns null if this isn't an array.
         /// </summary>
+        /// <returns>A list of wrapped values, or null when this value is not an array.</returns>
         public List<PostHogJson> AsList()
         {
             if (_value is List<object> list)
@@ -363,6 +377,7 @@ namespace PostHogUnity
         /// Converts to a list of strings (for string arrays).
         /// Returns null if this isn't an array.
         /// </summary>
+        /// <returns>A list of strings, or null when this value is not an array.</returns>
         public List<string> AsStringList()
         {
             var list = AsList();
@@ -381,6 +396,7 @@ namespace PostHogUnity
         /// Converts to a list of integers (for number arrays).
         /// Returns null if this isn't an array.
         /// </summary>
+        /// <returns>A list of integers, or null when this value is not an array.</returns>
         public List<int> AsIntList()
         {
             var list = AsList();
@@ -402,32 +418,44 @@ namespace PostHogUnity
         /// <summary>
         /// Implicit conversion from PostHogJson to string.
         /// </summary>
+        /// <param name="json">The JSON value to convert.</param>
+        /// <returns>The converted string value, or null.</returns>
         public static implicit operator string(PostHogJson json) => json?.GetString();
 
         /// <summary>
         /// Implicit conversion from PostHogJson to int.
         /// </summary>
+        /// <param name="json">The JSON value to convert.</param>
+        /// <returns>The converted integer value, or 0.</returns>
         public static implicit operator int(PostHogJson json) => json?.GetInt() ?? 0;
 
         /// <summary>
         /// Implicit conversion from PostHogJson to bool.
         /// </summary>
+        /// <param name="json">The JSON value to convert.</param>
+        /// <returns>The converted boolean value, or false.</returns>
         public static implicit operator bool(PostHogJson json) => json?.GetBool() ?? false;
 
         /// <summary>
         /// Implicit conversion from PostHogJson to float.
         /// </summary>
+        /// <param name="json">The JSON value to convert.</param>
+        /// <returns>The converted float value, or 0.</returns>
         public static implicit operator float(PostHogJson json) => json?.GetFloat() ?? 0f;
 
         /// <summary>
         /// Implicit conversion from PostHogJson to double.
         /// </summary>
+        /// <param name="json">The JSON value to convert.</param>
+        /// <returns>The converted double value, or 0.</returns>
         public static implicit operator double(PostHogJson json) => json?.GetDouble() ?? 0.0;
 
         /// <summary>
         /// Returns true if the value is not null.
         /// Allows using PostHogJson directly in if statements.
         /// </summary>
+        /// <param name="json">The JSON value to evaluate.</param>
+        /// <returns>True when the value is non-null, or null when the wrapper or value is null.</returns>
         public static implicit operator bool?(PostHogJson json)
         {
             if (json == null || json.IsNull)
@@ -438,6 +466,7 @@ namespace PostHogUnity
         /// <summary>
         /// Returns the string representation of the value.
         /// </summary>
+        /// <returns>A readable representation of the wrapped value.</returns>
         public override string ToString()
         {
             if (_value == null)
@@ -452,6 +481,8 @@ namespace PostHogUnity
         /// <summary>
         /// Checks equality with another PostHogJson.
         /// </summary>
+        /// <param name="obj">The object to compare with this value.</param>
+        /// <returns>True when the wrapped values are equal.</returns>
         public override bool Equals(object obj)
         {
             if (obj is PostHogJson other)
@@ -464,6 +495,7 @@ namespace PostHogUnity
         /// <summary>
         /// Gets the hash code.
         /// </summary>
+        /// <returns>The hash code for the wrapped value, or 0 when null.</returns>
         public override int GetHashCode()
         {
             return _value?.GetHashCode() ?? 0;


### PR DESCRIPTION
## :bulb: Motivation and Context
Improve the generated XML/API documentation for SDK users and make validation expectations clearer in public configuration and helper APIs.

Changes include:
- Added missing `<param>`, `<returns>`, `<exception>`, and `<inheritdoc />` XML documentation across public APIs.
- Clarified configuration validation constraints and default behavior for queue, flush, batch, and session replay settings.
- Improved documentation for feature flag payloads, storage providers, RRWeb session replay models, network telemetry, and PostHogJson conversions.

## :green_heart: How did you test it?
Not run; documentation-only changes.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
