### PR TITLE
chore: update Sentry license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,7 +22,7 @@ SOFTWARE.
 
 ---
 
-Some files in this codebase contain code from getsentry/sentry-unity by Sentry.
+Some files in this codebase contain code from getsentry/sentry-unity.
 In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
 
 MIT License

--- a/com.posthog.unity/LICENSE
+++ b/com.posthog.unity/LICENSE
@@ -22,7 +22,7 @@ SOFTWARE.
 
 ---
 
-Some files in this codebase contain code from getsentry/sentry-unity by Sentry.
+Some files in this codebase contain code from getsentry/sentry-unity.
 In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
 
 MIT License

--- a/com.posthog.unity/Runtime/ErrorTracking/ExceptionManager.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/ExceptionManager.cs
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-unity by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-unity
+// Copyright (c) 2021 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-unity/blob/main/LICENSE.md
 
 using System;
 using System.Collections.Generic;

--- a/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-unity by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-unity
+// Copyright (c) 2021 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-unity/blob/main/LICENSE.md
 
 using System;
 using System.Collections.Generic;

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-unity by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-unity
+// Copyright (c) 2021 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-unity/blob/main/LICENSE.md
 
 using System;
 using UnityEngine;

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-unity by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-unity
+// Copyright (c) 2021 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-unity/blob/main/LICENSE.md
 
 using System;
 using System.Collections.Generic;

--- a/com.posthog.unity/Runtime/ErrorTracking/WebGLExceptionIntegration.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/WebGLExceptionIntegration.cs
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-unity by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-unity
+// Copyright (c) 2021 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-unity/blob/main/LICENSE.md
 
 using System;
 using UnityEngine;


### PR DESCRIPTION
## :bulb: Motivation and Context

Update Sentry-derived source attribution and bundled license wording so the copyright holder and upstream MIT license URL are stated explicitly.

Changes:
- Clarified Sentry-derived file headers in error tracking sources.
- Updated the root and package license attribution text for getsentry/sentry-unity.

## :green_heart: How did you test it?

Not run; license/header-only changes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
