### PR TITLE
docs: remove beta and experimental notes

### DIFF
--- a/.changeset/brave-geese-dance.md
+++ b/.changeset/brave-geese-dance.md
@@ -1,0 +1,5 @@
+---
+"com.posthog.unity": major
+---
+
+Release PostHog Unity SDK 1.0.0.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PostHog Unity SDK (BETA)
+# PostHog Unity SDK
 
 The [official PostHog analytics SDK for Unity](https://posthog.com/docs/libraries/unity). Capture events, identify users, and track sessions in your Unity games and applications.
 
@@ -61,7 +61,7 @@ PostHog.Setup(new PostHogConfig
     MaxBatchSize = 50,                      // Max events per request
     CaptureApplicationLifecycleEvents = true,
     CaptureExceptions = true,               // Auto-capture unhandled exceptions
-    SessionReplay = false,                  // Enable session replay (experimental)
+    SessionReplay = false,                  // Enable session replay
     PersonProfiles = PersonProfiles.IdentifiedOnly,
     LogLevel = PostHogLogLevel.Warning
 });
@@ -191,7 +191,7 @@ Set properties used for flag evaluation:
 PostHog.SetPersonPropertiesForFlags(new Dictionary<string, object>
 {
     { "plan", "premium" },
-    { "beta_user", true }
+    { "power_user", true }
 });
 
 // Set group properties for targeting
@@ -307,9 +307,7 @@ PostHog.Setup(new PostHogConfig
 });
 ```
 
-## Session Replay (Experimental)
-
-> **Note:** Session replay is an experimental feature of this beta SDK. Performance impact varies significantly depending on your target devices and game complexity. You may need to adjust capture settings (screenshot scale, quality, throttle delay) to find the right balance for your users. We welcome your feedback—please [open an issue](https://github.com/PostHog/posthog-unity/issues) or reach out if you encounter problems or need help tuning for your use case.
+## Session Replay
 
 Record user sessions for replay in PostHog. Session replay captures screenshots of your game at regular intervals along with console logs and network telemetry.
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Set properties used for flag evaluation:
 PostHog.SetPersonPropertiesForFlags(new Dictionary<string, object>
 {
     { "plan", "premium" },
-    { "power_user", true }
+    { "beta_user", true }
 });
 
 // Set group properties for targeting


### PR DESCRIPTION
## :bulb: Motivation and Context
Remove beta/experimental stability language from the README so the docs describe the SDK and session replay without stability qualifiers. Add a changeset to release the SDK as 1.0.0.

## :green_heart: How did you test it?
- Verified the README diff.
- Ran `pnpm changeset status --verbose` and confirmed `com.posthog.unity` will be bumped to `1.0.0`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
