### PR TITLE
ci: add public API baseline check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
         run: ./bin/build
         shell: bash
 
+      - name: Check public API
+        # If this fails because the public API changed intentionally, regenerate the baseline with:
+        # ./bin/check-public-api --update
+        run: ./bin/check-public-api
+        shell: bash
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
-          fetch-depth: 0
 
       - name: Check for changesets
         id: check
@@ -88,7 +87,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
-          fetch-depth: 0
           token: ${{ steps.releaser.outputs.token }}
 
       - name: Configure Git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Check for changesets
         id: check
@@ -87,6 +88,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
+          fetch-depth: 0
           token: ${{ steps.releaser.outputs.token }}
 
       - name: Configure Git

--- a/api/PostHog.PublicAPI.Shipped.txt
+++ b/api/PostHog.PublicAPI.Shipped.txt
@@ -1,0 +1,375 @@
+namespace PostHogUnity
+{
+    [System.Serializable]
+    public class BatchPayload
+    {
+        public BatchPayload() { }
+        public BatchPayload(string apiKey, System.Collections.Generic.List<PostHogUnity.PostHogEvent> events) { }
+        public string ApiKey { get; set; }
+        public System.Collections.Generic.List<PostHogUnity.PostHogEvent> Batch { get; set; }
+        public string SentAt { get; set; }
+    }
+    public class FileStorageProvider : PostHogUnity.IStorageProvider
+    {
+        public FileStorageProvider() { }
+        public void Clear() { }
+        public void DeleteEvent(string id) { }
+        public void DeleteState(string key) { }
+        public void FlushPendingWrites() { }
+        public int GetEventCount() { }
+        public System.Collections.Generic.IReadOnlyList<string> GetEventIds() { }
+        public void Initialize(string basePath) { }
+        public string LoadEvent(string id) { }
+        public string LoadState(string key) { }
+        public void SaveEvent(string id, string jsonData) { }
+        public void SaveState(string key, string jsonData) { }
+    }
+    public readonly struct FlagValue
+    {
+        public bool BoolValue { get; }
+        public bool HasValue { get; }
+        public bool IsBool { get; }
+        public bool IsEnabled { get; }
+        public bool IsString { get; }
+        public string StringValue { get; }
+        public override string ToString() { }
+        public static bool op_Implicit(PostHogUnity.FlagValue value) { }
+    }
+    public interface IStorageProvider
+    {
+        void Clear();
+        void DeleteEvent(string id);
+        void DeleteState(string key);
+        int GetEventCount();
+        System.Collections.Generic.IReadOnlyList<string> GetEventIds();
+        void Initialize(string basePath);
+        string LoadEvent(string id);
+        string LoadState(string key);
+        void SaveEvent(string id, string jsonData);
+        void SaveState(string key, string jsonData);
+    }
+    public enum PersonProfiles
+    {
+        Always = 0,
+        IdentifiedOnly = 1,
+        Never = 2,
+    }
+    public class PlayerPrefsStorageProvider : PostHogUnity.IStorageProvider
+    {
+        public PlayerPrefsStorageProvider() { }
+        public void Clear() { }
+        public void DeleteEvent(string id) { }
+        public void DeleteState(string key) { }
+        public int GetEventCount() { }
+        public System.Collections.Generic.IReadOnlyList<string> GetEventIds() { }
+        public void Initialize(string basePath) { }
+        public string LoadEvent(string id) { }
+        public string LoadState(string key) { }
+        public void SaveEvent(string id, string jsonData) { }
+        public void SaveState(string key, string jsonData) { }
+    }
+    public static class PostHog
+    {
+        public static string DistinctId { get; }
+        public static bool IsInitialized { get; }
+        public static bool IsOptedOut { get; }
+        public static event System.Action OnFeatureFlagsLoaded;
+        public static void Alias(string alias) { }
+        public static void Capture(string eventName, System.Collections.Generic.Dictionary<string, object> properties = null) { }
+        public static void CaptureException(System.Exception exception, System.Collections.Generic.Dictionary<string, object> properties = null) { }
+        public static void Flush() { }
+        public static PostHogUnity.PostHogFeatureFlag GetFeatureFlag(string key) { }
+        public static void Group(string groupType, string groupKey, System.Collections.Generic.Dictionary<string, object> groupProperties = null) { }
+        public static System.Threading.Tasks.Task IdentifyAsync(string distinctId) { }
+        public static System.Threading.Tasks.Task IdentifyAsync(string distinctId, System.Collections.Generic.Dictionary<string, object> userProperties, System.Collections.Generic.Dictionary<string, object> userPropertiesSetOnce = null) { }
+        public static bool IsFeatureEnabled(string key, bool defaultValue = false) { }
+        public static void OptIn() { }
+        public static void OptOut() { }
+        public static void Register(string key, object value) { }
+        public static System.Threading.Tasks.Task ReloadFeatureFlagsAsync() { }
+        public static System.Threading.Tasks.Task ResetAsync() { }
+        public static void ResetGroupPropertiesForFlags(bool reloadFeatureFlags = true) { }
+        public static void ResetGroupPropertiesForFlags(string groupType, bool reloadFeatureFlags = true) { }
+        public static void ResetPersonPropertiesForFlags(bool reloadFeatureFlags = true) { }
+        public static void Screen(string screenName, System.Collections.Generic.Dictionary<string, object> properties = null) { }
+        public static void SetGroupPropertiesForFlags(string groupType, System.Collections.Generic.Dictionary<string, object> properties, bool reloadFeatureFlags = true) { }
+        public static void SetPersonPropertiesForFlags(System.Collections.Generic.Dictionary<string, object> properties, bool reloadFeatureFlags = true) { }
+        public static void Setup(PostHogUnity.PostHogConfig config) { }
+        public static void Shutdown() { }
+        public static void Unregister(string key) { }
+    }
+    [System.Serializable]
+    public class PostHogConfig
+    {
+        public PostHogConfig() { }
+        public string ApiKey { get; set; }
+        public bool CaptureApplicationLifecycleEvents { get; set; }
+        public bool CaptureExceptions { get; set; }
+        public bool CaptureExceptionsInEditor { get; set; }
+        public int ExceptionDebounceIntervalMs { get; set; }
+        public int FlushAt { get; set; }
+        public int FlushIntervalSeconds { get; set; }
+        public bool FlushOnQuit { get; set; }
+        public float FlushOnQuitTimeoutSeconds { get; set; }
+        public string Host { get; set; }
+        public PostHogUnity.PostHogLogLevel LogLevel { get; set; }
+        public int MaxBatchSize { get; set; }
+        public int MaxQueueSize { get; set; }
+        public System.Action OnFeatureFlagsLoaded { get; set; }
+        public System.Func<string, System.Type, object> PayloadDeserializer { get; set; }
+        public PostHogUnity.PersonProfiles PersonProfiles { get; set; }
+        public bool PreloadFeatureFlags { get; set; }
+        public bool ReuseAnonymousId { get; set; }
+        public bool SendDefaultPersonPropertiesForFlags { get; set; }
+        public bool SendFeatureFlagEvent { get; set; }
+        public bool SessionReplay { get; set; }
+        public PostHogUnity.SessionReplay.PostHogSessionReplayConfig SessionReplayConfig { get; set; }
+        public void Validate() { }
+    }
+    [System.Serializable]
+    public class PostHogEvent
+    {
+        public PostHogEvent() { }
+        public PostHogEvent(string eventName, string distinctId) { }
+        public PostHogEvent(string eventName, string distinctId, System.Collections.Generic.Dictionary<string, object> properties) { }
+        public string DistinctId { get; set; }
+        public string Event { get; set; }
+        public System.Collections.Generic.Dictionary<string, object> Properties { get; set; }
+        public string Timestamp { get; set; }
+        public string Uuid { get; set; }
+    }
+    public class PostHogFeatureFlag
+    {
+        public static readonly PostHogUnity.PostHogFeatureFlag Null;
+        public bool HasPayload { get; }
+        public bool IsEnabled { get; }
+        public string Key { get; }
+        public PostHogUnity.FlagValue Value { get; }
+        public T GetPayload<T>(T defaultValue = default) { }
+        public PostHogUnity.PostHogJson GetPayloadJson() { }
+        public string GetVariant(string defaultValue = null) { }
+        public override string ToString() { }
+        public static bool op_Implicit(PostHogUnity.PostHogFeatureFlag flag) { }
+    }
+    public class PostHogJson
+    {
+        public static readonly PostHogUnity.PostHogJson Null;
+        public PostHogJson(object value) { }
+        public int Count { get; }
+        public bool IsArray { get; }
+        public bool IsBool { get; }
+        public bool IsNull { get; }
+        public bool IsNumber { get; }
+        public bool IsObject { get; }
+        public bool IsString { get; }
+        public PostHogUnity.PostHogJson this[string key] { get; }
+        public PostHogUnity.PostHogJson this[int index] { get; }
+        public System.Collections.Generic.IEnumerable<string> Keys { get; }
+        public object RawValue { get; }
+        public System.Collections.Generic.Dictionary<string, PostHogUnity.PostHogJson> AsDictionary() { }
+        public System.Collections.Generic.List<int> AsIntList() { }
+        public System.Collections.Generic.List<PostHogUnity.PostHogJson> AsList() { }
+        public System.Collections.Generic.List<string> AsStringList() { }
+        public bool ContainsKey(string key) { }
+        public override bool Equals(object obj) { }
+        public bool GetBool(bool defaultValue = false) { }
+        public double GetDouble(double defaultValue = 0) { }
+        public float GetFloat(float defaultValue = 0) { }
+        public override int GetHashCode() { }
+        public int GetInt(int defaultValue = 0) { }
+        public long GetLong(long defaultValue = 0) { }
+        public PostHogUnity.PostHogJson GetPath(string path) { }
+        public string GetString(string defaultValue = null) { }
+        public override string ToString() { }
+        public static PostHogUnity.PostHogJson Parse(string json) { }
+        public static string op_Implicit(PostHogUnity.PostHogJson json) { }
+        public static int op_Implicit(PostHogUnity.PostHogJson json) { }
+        public static bool op_Implicit(PostHogUnity.PostHogJson json) { }
+        public static float op_Implicit(PostHogUnity.PostHogJson json) { }
+        public static double op_Implicit(PostHogUnity.PostHogJson json) { }
+        public static bool? op_Implicit(PostHogUnity.PostHogJson json) { }
+    }
+    public enum PostHogLogLevel
+    {
+        Debug = 0,
+        Info = 1,
+        Warning = 2,
+        Error = 3,
+        None = 4,
+    }
+    public class PostHogSDK : UnityEngine.MonoBehaviour
+    {
+        public PostHogSDK() { }
+        public static string DistinctId { get; }
+        public static PostHogUnity.PostHogSDK Instance { get; }
+        public static bool IsInitialized { get; }
+        public static bool IsOptedOut { get; }
+        public static bool IsSessionReplayActive { get; }
+        public static event System.Action OnFeatureFlagsLoaded;
+        public static void Alias(string alias) { }
+        public static void Capture(string eventName, System.Collections.Generic.Dictionary<string, object> properties = null) { }
+        public static void CaptureException(System.Exception exception, System.Collections.Generic.Dictionary<string, object> properties = null) { }
+        public static void Flush() { }
+        public static PostHogUnity.PostHogFeatureFlag GetFeatureFlag(string key) { }
+        public static void Group(string groupType, string groupKey, System.Collections.Generic.Dictionary<string, object> groupProperties = null) { }
+        public static System.Threading.Tasks.Task IdentifyAsync(string distinctId) { }
+        public static System.Threading.Tasks.Task IdentifyAsync(string distinctId, System.Collections.Generic.Dictionary<string, object> userProperties, System.Collections.Generic.Dictionary<string, object> userPropertiesSetOnce = null) { }
+        public static bool IsFeatureEnabled(string key, bool defaultValue = false) { }
+        public static void OptIn() { }
+        public static void OptOut() { }
+        public static void RecordNetworkRequest(string method, string url, int statusCode, long durationMs, long responseSize = 0) { }
+        public static void Register(string key, object value) { }
+        public static System.Threading.Tasks.Task ReloadFeatureFlagsAsync() { }
+        public static System.Threading.Tasks.Task ResetAsync() { }
+        public static void ResetGroupPropertiesForFlags(bool reloadFeatureFlags = true) { }
+        public static void ResetGroupPropertiesForFlags(string groupType, bool reloadFeatureFlags = true) { }
+        public static void ResetPersonPropertiesForFlags(bool reloadFeatureFlags = true) { }
+        public static void Screen(string screenName, System.Collections.Generic.Dictionary<string, object> properties = null) { }
+        public static void SetGroupPropertiesForFlags(string groupType, System.Collections.Generic.Dictionary<string, object> properties, bool reloadFeatureFlags = true) { }
+        public static void SetPersonPropertiesForFlags(System.Collections.Generic.Dictionary<string, object> properties, bool reloadFeatureFlags = true) { }
+        public static void Setup(PostHogUnity.PostHogConfig config) { }
+        public static void Shutdown() { }
+        public static void StartSessionReplay() { }
+        public static void StopSessionReplay() { }
+        public static void Unregister(string key) { }
+    }
+    [UnityEngine.CreateAssetMenu(fileName="PostHogSettings", menuName="PostHog/Settings", order=1)]
+    public class PostHogSettings : UnityEngine.ScriptableObject
+    {
+        public PostHogSettings() { }
+        public string ApiKey { get; }
+        public bool AutoInitialize { get; }
+        public bool CaptureApplicationLifecycleEvents { get; }
+        public bool CaptureExceptions { get; }
+        public bool CaptureExceptionsInEditor { get; }
+        public int ExceptionDebounceIntervalMs { get; }
+        public int FlushAt { get; }
+        public int FlushIntervalSeconds { get; }
+        public string Host { get; }
+        public PostHogUnity.PostHogLogLevel LogLevel { get; }
+        public int MaxBatchSize { get; }
+        public int MaxQueueSize { get; }
+        public PostHogUnity.PersonProfiles PersonProfiles { get; }
+        public bool PreloadFeatureFlags { get; }
+        public bool ReuseAnonymousId { get; }
+        public bool SendDefaultPersonPropertiesForFlags { get; }
+        public bool SendFeatureFlagEvent { get; }
+        public PostHogUnity.PostHogConfig ToConfig() { }
+        public static PostHogUnity.PostHogSettings Load() { }
+    }
+    public static class UuidV7
+    {
+        public static string Generate() { }
+        public static byte[] GenerateBytes() { }
+    }
+}
+namespace PostHogUnity.SessionReplay
+{
+    public class LogEntry
+    {
+        public LogEntry() { }
+        public string Level { get; set; }
+        public string Message { get; set; }
+        public string StackTrace { get; set; }
+        public long Timestamp { get; set; }
+        public System.Collections.Generic.Dictionary<string, object> ToDictionary() { }
+    }
+    public class NetworkSample
+    {
+        public NetworkSample() { }
+        public long Duration { get; set; }
+        public string EntryType { get; set; }
+        public string InitiatorType { get; set; }
+        public string Method { get; set; }
+        public string Name { get; set; }
+        public int ResponseStatus { get; set; }
+        public long Timestamp { get; set; }
+        public long TransferSize { get; set; }
+        public System.Collections.Generic.Dictionary<string, object> ToDictionary() { }
+    }
+    public static class NetworkTelemetryExtensions
+    {
+        public static void RecordForReplay(string method, string url, int statusCode, long durationMs, long responseSize = 0) { }
+    }
+    [System.Serializable]
+    public class PostHogSessionReplayConfig
+    {
+        public PostHogSessionReplayConfig() { }
+        public bool CaptureLogs { get; set; }
+        public bool CaptureNetworkTelemetry { get; set; }
+        public int FlushAt { get; set; }
+        public int FlushIntervalSeconds { get; set; }
+        public int MaxQueueSize { get; set; }
+        public PostHogUnity.SessionReplay.SessionReplayLogLevel MinLogLevel { get; set; }
+        public int ScreenshotQuality { get; set; }
+        public float ScreenshotScale { get; set; }
+        public float ThrottleDelaySeconds { get; set; }
+        public void Validate() { }
+    }
+    public class RREvent
+    {
+        public RREvent() { }
+        public System.Collections.Generic.Dictionary<string, object> Data { get; set; }
+        public long Timestamp { get; set; }
+        public int Type { get; set; }
+        public System.Collections.Generic.Dictionary<string, object> ToDictionary() { }
+        public static PostHogUnity.SessionReplay.RREvent CreateConsoleLogPlugin(System.Collections.Generic.List<PostHogUnity.SessionReplay.LogEntry> logs, long timestamp) { }
+        public static PostHogUnity.SessionReplay.RREvent CreateFullSnapshot(PostHogUnity.SessionReplay.RRWireframe wireframe, long timestamp) { }
+        public static PostHogUnity.SessionReplay.RREvent CreateMeta(int width, int height, string screenName, long timestamp) { }
+        public static PostHogUnity.SessionReplay.RREvent CreateNetworkPlugin(System.Collections.Generic.List<PostHogUnity.SessionReplay.NetworkSample> requests, long timestamp) { }
+        public static PostHogUnity.SessionReplay.RREvent CreatePointerEvent(float x, float y, int touchType, long timestamp) { }
+    }
+    public static class RREventType
+    {
+        public const int FullSnapshot = 2;
+        public const int IncrementalSnapshot = 3;
+        public const int Meta = 4;
+        public const int Plugin = 6;
+    }
+    public class RRStyle
+    {
+        public RRStyle() { }
+        public string BackgroundColor { get; set; }
+        public string BorderColor { get; set; }
+        public int? BorderRadius { get; set; }
+        public int? BorderWidth { get; set; }
+        public string Color { get; set; }
+        public string FontFamily { get; set; }
+        public int? FontSize { get; set; }
+        public System.Collections.Generic.Dictionary<string, object> ToDictionary() { }
+    }
+    public static class RRTouchType
+    {
+        public const int TouchEnd = 9;
+        public const int TouchMove = 3;
+        public const int TouchStart = 7;
+    }
+    public class RRWireframe
+    {
+        public RRWireframe() { }
+        public string Base64 { get; set; }
+        public int Height { get; set; }
+        public int Id { get; set; }
+        public PostHogUnity.SessionReplay.RRStyle Style { get; set; }
+        public string Type { get; set; }
+        public int Width { get; set; }
+        public int X { get; set; }
+        public int Y { get; set; }
+        public System.Collections.Generic.Dictionary<string, object> ToDictionary() { }
+        public static PostHogUnity.SessionReplay.RRWireframe CreateScreenshot(int width, int height, string base64Data) { }
+    }
+    public static class RRWireframeType
+    {
+        public const string Image = "image";
+        public const string Input = "input";
+        public const string Rectangle = "div";
+        public const string Screenshot = "screenshot";
+        public const string Text = "text";
+    }
+    public enum SessionReplayLogLevel
+    {
+        Log = 0,
+        Warning = 1,
+        Error = 2,
+    }
+}

--- a/bin/check-public-api
+++ b/bin/check-public-api
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#/ Usage: bin/check-public-api [-u|--update]
+#/ Description: Checks the Unity runtime assembly public API against the committed snapshot.
+#/ Options:
+#/   -u, --update   Regenerate the public API snapshot.
+set -euo pipefail
+source bin/helpers/_utils.sh
+set_source_and_root_dir
+
+SNAPSHOT_FILE="./api/PostHog.PublicAPI.Shipped.txt"
+WORK_DIR="./obj/public-api"
+RUNTIME_PROJECT_DIR="$WORK_DIR/runtime"
+GENERATOR_PROJECT_DIR="$WORK_DIR/generator"
+RUNTIME_PROJECT="$RUNTIME_PROJECT_DIR/PostHog.PublicApi.Runtime.csproj"
+GENERATOR_PROJECT="$GENERATOR_PROJECT_DIR/PostHog.PublicApi.Generator.csproj"
+GENERATED_API="$WORK_DIR/PostHog.PublicAPI.Generated.txt"
+RUNTIME_ASSEMBLY="$RUNTIME_PROJECT_DIR/bin/Release/netstandard2.1/PostHog.dll"
+
+update=false
+
+while (( "$#" )); do
+    key="$1"
+    shift
+    case "$key" in
+        -u|--update)
+            update=true
+            ;;
+        -\?|-h|--help)
+            grep '^#/' <"$0" | cut -c4-
+            exit
+            ;;
+        *)
+            echo "Unknown option: $key" 1>&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! type dotnet >/dev/null 2>&1; then
+    echo ".NET CLI is not installed!" 1>&2
+    exit 1
+fi
+
+rm -rf "$WORK_DIR"
+mkdir -p "$RUNTIME_PROJECT_DIR" "$GENERATOR_PROJECT_DIR"
+
+cat > "$RUNTIME_PROJECT" << PROJ
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyName>PostHog</AssemblyName>
+    <RootNamespace>PostHogUnity</RootNamespace>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>disable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NoWarn>NU1701</NoWarn>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$root_dir/com.posthog.unity/Runtime/**/*.cs" LinkBase="Runtime" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Unity3D.SDK" Version="2021.1.14.1" />
+  </ItemGroup>
+</Project>
+PROJ
+
+cat > "$GENERATOR_PROJECT" << 'PROJ'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="PublicApiGenerator" Version="11.5.0" />
+  </ItemGroup>
+</Project>
+PROJ
+
+cat > "$GENERATOR_PROJECT_DIR/Program.cs" << 'CS'
+using System.Reflection;
+using System.Runtime.Loader;
+using PublicApiGenerator;
+
+if (args.Length != 1)
+{
+    Console.Error.WriteLine("Usage: generator <assembly-path>");
+    return 1;
+}
+
+var assemblyPath = Path.GetFullPath(args[0]);
+var loadContext = new ApiAssemblyLoadContext(assemblyPath);
+var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+
+var publicApi = assembly.GeneratePublicApi(
+    new ApiGeneratorOptions
+    {
+        IncludeAssemblyAttributes = false,
+    }
+);
+
+Console.Write(publicApi.Replace("\r\n", "\n").TrimEnd());
+Console.WriteLine();
+return 0;
+
+sealed class ApiAssemblyLoadContext : AssemblyLoadContext
+{
+    readonly AssemblyDependencyResolver _resolver;
+
+    public ApiAssemblyLoadContext(string assemblyPath)
+        : base(isCollectible: false)
+    {
+        _resolver = new AssemblyDependencyResolver(assemblyPath);
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        return assemblyPath is null ? null : LoadFromAssemblyPath(assemblyPath);
+    }
+}
+CS
+
+echo "Building runtime assembly for public API generation..."
+dotnet build "$RUNTIME_PROJECT" --configuration Release --nologo --verbosity quiet
+
+echo "Generating public API snapshot..."
+dotnet run --project "$GENERATOR_PROJECT" --no-launch-profile -- "$RUNTIME_ASSEMBLY" > "$GENERATED_API"
+
+if $update; then
+    mkdir -p "$(dirname "$SNAPSHOT_FILE")"
+    cp "$GENERATED_API" "$SNAPSHOT_FILE"
+    echo "Updated $SNAPSHOT_FILE"
+    exit
+fi
+
+if [[ ! -f "$SNAPSHOT_FILE" ]]; then
+    echo "Public API snapshot is missing: $SNAPSHOT_FILE" 1>&2
+    echo "Run './bin/check-public-api --update' to create it." 1>&2
+    exit 1
+fi
+
+if diff -u "$SNAPSHOT_FILE" "$GENERATED_API"; then
+    echo "Public API snapshot is up to date."
+else
+    echo "Public API has changed. Run './bin/check-public-api --update' if this change is intentional." 1>&2
+    exit 1
+fi


### PR DESCRIPTION
## :bulb: Motivation and Context
Add CI coverage so intentional public API changes are reviewed against a committed baseline. The workflow comment now tells contributors how to regenerate the baseline when a public API change is intentional.


## :green_heart: How did you test it?

- [x] Ran `./bin/check-public-api`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
