### PR TITLE
test: exercise public api baseline check

### DIFF
--- a/com.posthog.unity/Runtime/PostHog.cs
+++ b/com.posthog.unity/Runtime/PostHog.cs
@@ -134,6 +134,11 @@ namespace PostHogUnity
         public static void Flush() => PostHogSDK.Flush();
 
         /// <summary>
+        /// Public API baseline check probe.
+        /// </summary>
+        public static void PublicApiBaselineProbe() { }
+
+        /// <summary>
         /// Opts out of tracking. No events will be captured.
         /// </summary>
         public static void OptOut() => PostHogSDK.OptOut();


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Exercise the public API baseline check added in #89 by adding a new public API without updating `api/PostHog.PublicAPI.Shipped.txt`.

This draft PR is intended to verify CI reports the baseline mismatch.


## :green_heart: How did you test it?

- [x] Ran `./bin/check-public-api` and confirmed it fails with the expected diff for `PostHog.PublicApiBaselineProbe()`.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->