### PR TITLE
fix: send SDK user agent header

### DIFF
--- a/.changeset/unity-user-agent.md
+++ b/.changeset/unity-user-agent.md
@@ -1,0 +1,5 @@
+---
+"com.posthog.unity": patch
+---
+
+Send the SDK User-Agent header on PostHog API requests.

--- a/com.posthog.unity/Runtime/Core/NetworkClient.cs
+++ b/com.posthog.unity/Runtime/Core/NetworkClient.cs
@@ -36,8 +36,7 @@ namespace PostHogUnity
             var bodyRaw = Encoding.UTF8.GetBytes(json);
             request.uploadHandler = new UploadHandlerRaw(bodyRaw);
             request.downloadHandler = new DownloadHandlerBuffer();
-            request.SetRequestHeader("Content-Type", "application/json");
-            request.SetRequestHeader("Accept", "application/json");
+            ApplyDefaultHeaders(request);
             request.timeout = TimeoutSeconds;
 
             yield return request.SendWebRequest();
@@ -170,11 +169,17 @@ namespace PostHogUnity
             var bodyRaw = Encoding.UTF8.GetBytes(json);
             request.uploadHandler = new UploadHandlerRaw(bodyRaw);
             request.downloadHandler = new DownloadHandlerBuffer();
-            request.SetRequestHeader("Content-Type", "application/json");
-            request.SetRequestHeader("Accept", "application/json");
+            ApplyDefaultHeaders(request);
             request.timeout = TimeoutSeconds;
 
             return request;
+        }
+
+        static void ApplyDefaultHeaders(UnityWebRequest request)
+        {
+            request.SetRequestHeader("Content-Type", "application/json");
+            request.SetRequestHeader("Accept", "application/json");
+            request.SetRequestHeader("User-Agent", SdkInfo.UserAgent);
         }
     }
 }

--- a/com.posthog.unity/Runtime/Utilities/SdkInfo.cs
+++ b/com.posthog.unity/Runtime/Utilities/SdkInfo.cs
@@ -9,5 +9,10 @@ namespace PostHogUnity
         /// The SDK library name.
         /// </summary>
         public const string LibraryName = "posthog-unity";
+
+        /// <summary>
+        /// The SDK User-Agent header value.
+        /// </summary>
+        public const string UserAgent = LibraryName + "/" + Version;
     }
 }

--- a/tests/PostHog.Unity.Tests/SdkInfoTests.cs
+++ b/tests/PostHog.Unity.Tests/SdkInfoTests.cs
@@ -1,0 +1,13 @@
+using PostHogUnity;
+
+namespace PostHogUnity.Tests
+{
+    public class SdkInfoTests
+    {
+        [Fact]
+        public void UserAgent_UsesLibraryNameAndVersion()
+        {
+            Assert.Equal($"{SdkInfo.LibraryName}/{SdkInfo.Version}", SdkInfo.UserAgent);
+        }
+    }
+}

--- a/tests/PostHog.Unity.Tests/SdkInfoTests.cs
+++ b/tests/PostHog.Unity.Tests/SdkInfoTests.cs
@@ -7,7 +7,7 @@ namespace PostHogUnity.Tests
         [Fact]
         public void UserAgent_UsesLibraryNameAndVersion()
         {
-            Assert.Equal($"{SdkInfo.LibraryName}/{SdkInfo.Version}", SdkInfo.UserAgent);
+            Assert.Equal("posthog-unity/" + SdkInfo.Version, SdkInfo.UserAgent);
         }
     }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
PostHog API requests from the Unity SDK should identify the SDK and version consistently via the HTTP User-Agent header.

This adds a shared `posthog-unity/<version>` User-Agent value and sends it with JSON API requests.

## :green_heart: How did you test it?
- `dotnet test posthog-unity.sln`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
