### PR TITLE
fix: Reset feature flag called tracking on shutdown

### DIFF
--- a/.changeset/calm-flags-reset.md
+++ b/.changeset/calm-flags-reset.md
@@ -1,0 +1,5 @@
+---
+'com.posthog.unity': patch
+---
+
+Reset feature flag called tracking on shutdown.

--- a/com.posthog.unity/Runtime/FeatureFlags/FeatureFlagManager.cs
+++ b/com.posthog.unity/Runtime/FeatureFlags/FeatureFlagManager.cs
@@ -274,12 +274,20 @@ namespace PostHogUnity
         }
 
         /// <summary>
+        /// Clears the flag call tracking cache.
+        /// </summary>
+        public void ResetFlagCallTracking()
+        {
+            _flagCalledTracker.Reset();
+        }
+
+        /// <summary>
         /// Clears the flag cache.
         /// </summary>
         public void Clear()
         {
             _flagCache.Clear();
-            _flagCalledTracker.Reset();
+            ResetFlagCallTracking();
         }
 
         #region Person Properties for Flags

--- a/com.posthog.unity/Runtime/FeatureFlags/FeatureFlagManager.cs
+++ b/com.posthog.unity/Runtime/FeatureFlags/FeatureFlagManager.cs
@@ -110,7 +110,7 @@ namespace PostHogUnity
             }
 
             // Reset tracking on reload (same flag/value should trigger new event)
-            _flagCalledTracker.Reset();
+            ResetFlagCallTracking();
 
             monoBehaviour.StartCoroutine(FetchFlagsCoroutine(onComplete));
         }

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -269,6 +269,8 @@ namespace PostHogUnity
             // Stop exception tracking
             _exceptionManager?.Stop();
 
+            _featureFlagManager?.ResetFlagCallTracking();
+
             // Flush before stopping to ensure final events are sent
             _eventQueue?.Flush();
             _eventQueue?.Stop();
@@ -616,6 +618,7 @@ namespace PostHogUnity
         {
             _identityManager.Reset();
             _sessionManager.StartNewSession();
+            _featureFlagManager.ResetFlagCallTracking();
 
             // Clear cached person and group properties for flags (matches iOS/Android behavior)
             _featureFlagManager.ResetPersonPropertiesForFlags(

--- a/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using PostHogUnity;
 using UnityEngine;
 
@@ -5,6 +7,32 @@ namespace PostHogUnity.Tests
 {
     public class PostHogSDKTests
     {
+        sealed class InMemoryStorageProvider : IStorageProvider
+        {
+            readonly Dictionary<string, string> _events = new();
+            readonly Dictionary<string, string> _state = new();
+
+            public void Initialize(string basePath) { }
+
+            public void SaveEvent(string id, string jsonData) => _events[id] = jsonData;
+
+            public string LoadEvent(string id) => _events.GetValueOrDefault(id);
+
+            public void DeleteEvent(string id) => _events.Remove(id);
+
+            public IReadOnlyList<string> GetEventIds() => _events.Keys.ToList();
+
+            public int GetEventCount() => _events.Count;
+
+            public void Clear() => _events.Clear();
+
+            public void SaveState(string key, string jsonData) => _state[key] = jsonData;
+
+            public string LoadState(string key) => _state.GetValueOrDefault(key);
+
+            public void DeleteState(string key) => _state.Remove(key);
+        }
+
         sealed class NoopLogHandler : ILogHandler
         {
             public void LogException(Exception exception, UnityEngine.Object context) { }
@@ -64,6 +92,49 @@ namespace PostHogUnity.Tests
 
                 Assert.Null(exception);
                 Assert.False(PostHog.IsInitialized);
+            }
+        }
+
+        public class TheShutdownMethod
+        {
+            [Fact]
+            public void ResetsFeatureFlagCallTracking()
+            {
+                var capturedFlagCalledEvents = 0;
+                var config = new PostHogConfig { ApiKey = "test-api-key" };
+                var manager = new FeatureFlagManager(
+                    config,
+                    new InMemoryStorageProvider(),
+                    new NetworkClient(config),
+                    () => "user-1",
+                    () => "anon-1",
+                    () => new Dictionary<string, string>(),
+                    (_, _) => capturedFlagCalledEvents++
+                );
+
+                manager.TrackFlagCalled("beta-feature", true);
+                manager.TrackFlagCalled("beta-feature", true);
+                Assert.Equal(1, capturedFlagCalledEvents);
+
+                var sdk = (PostHogSDK)RuntimeHelpers.GetUninitializedObject(typeof(PostHogSDK));
+                var featureFlagManagerField = typeof(PostHogSDK).GetField(
+                    "_featureFlagManager",
+                    BindingFlags.Instance | BindingFlags.NonPublic
+                );
+                Assert.NotNull(featureFlagManagerField);
+                featureFlagManagerField.SetValue(sdk, manager);
+
+                var shutdownInternalMethod = typeof(PostHogSDK).GetMethod(
+                    "ShutdownInternal",
+                    BindingFlags.Instance | BindingFlags.NonPublic
+                );
+                Assert.NotNull(shutdownInternalMethod);
+
+                var exception = Record.Exception(() => shutdownInternalMethod.Invoke(sdk, null));
+
+                Assert.Null(exception);
+                manager.TrackFlagCalled("beta-feature", true);
+                Assert.Equal(2, capturedFlagCalledEvents);
             }
         }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Feature flag call tracking can persist across SDK shutdown/reset flows, causing feature flag calls to remain marked as already tracked after the SDK lifecycle changes.

## :green_heart: How did you test it?

- `dotnet test tests/PostHog.Unity.Tests/PostHog.Unity.Tests.csproj`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Generated `.changeset/calm-flags-reset.md` as a patch changeset

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was prepared by a Pi agent using repository inspection, `dotnet test`, Git, and GitHub CLI. It exposes a reset helper for feature flag call tracking, reuses it when clearing feature flags, and resets called-flag tracking during SDK shutdown and SDK reset so lifecycle boundaries do not retain the previous called cache.
