### PR TITLE
fix(flags): retry flag requests on transient network errors

### DIFF
--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -2,4 +2,4 @@
 'com.posthog.unity': patch
 ---
 
-Retry feature flag requests after transient network errors only.
+Retry feature flag requests after transient network errors only. The feature flag request retry count defaults to 1 and can be set to 0 to disable retries.

--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -2,4 +2,4 @@
 'com.posthog.unity': patch
 ---
 
-Retry feature flag requests after network errors only.
+Retry feature flag requests after transient network errors only.

--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -1,0 +1,5 @@
+---
+'com.posthog.unity': patch
+---
+
+Retry feature flag requests after network errors only.

--- a/api/PostHog.PublicAPI.Shipped.txt
+++ b/api/PostHog.PublicAPI.Shipped.txt
@@ -107,6 +107,7 @@ namespace PostHogUnity
         public bool CaptureExceptions { get; set; }
         public bool CaptureExceptionsInEditor { get; set; }
         public int ExceptionDebounceIntervalMs { get; set; }
+        public int FeatureFlagRequestMaxRetries { get; set; }
         public int FlushAt { get; set; }
         public int FlushIntervalSeconds { get; set; }
         public bool FlushOnQuit { get; set; }
@@ -243,6 +244,7 @@ namespace PostHogUnity
         public bool CaptureExceptions { get; }
         public bool CaptureExceptionsInEditor { get; }
         public int ExceptionDebounceIntervalMs { get; }
+        public int FeatureFlagRequestMaxRetries { get; }
         public int FlushAt { get; }
         public int FlushIntervalSeconds { get; }
         public string Host { get; }

--- a/com.posthog.unity/Runtime/Core/NetworkClient.cs
+++ b/com.posthog.unity/Runtime/Core/NetworkClient.cs
@@ -103,7 +103,7 @@ namespace PostHogUnity
                     }
 
                     if (
-                        !ShouldRetryFeatureFlagsRequest(request.result, statusCode)
+                        !ShouldRetryFeatureFlagsRequest(request.result, statusCode, request.error)
                         || attempt == FeatureFlagsMaxAttempts
                     )
                     {
@@ -131,10 +131,26 @@ namespace PostHogUnity
 
         internal static bool ShouldRetryFeatureFlagsRequest(
             UnityWebRequest.Result result,
-            int statusCode
+            int statusCode,
+            string error = null
         )
         {
-            return result == UnityWebRequest.Result.ConnectionError && statusCode == 0;
+            if (result != UnityWebRequest.Result.ConnectionError || statusCode != 0)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(error))
+            {
+                return true;
+            }
+
+            var lowerError = error.ToLowerInvariant();
+            return lowerError.Contains("timeout")
+                   || lowerError.Contains("timed out")
+                   || lowerError.Contains("reset")
+                   || lowerError.Contains("eof")
+                   || lowerError.Contains("connection lost");
         }
 
         static float GetFeatureFlagsRetryDelaySeconds(int failedAttempt)

--- a/com.posthog.unity/Runtime/Core/NetworkClient.cs
+++ b/com.posthog.unity/Runtime/Core/NetworkClient.cs
@@ -14,6 +14,8 @@ namespace PostHogUnity
     {
         readonly PostHogConfig _config;
         const int TimeoutSeconds = 10;
+        const int FeatureFlagsMaxAttempts = 3;
+        const float FeatureFlagsInitialRetryDelaySeconds = 0.5f;
 
         public NetworkClient(PostHogConfig config)
         {
@@ -73,33 +75,51 @@ namespace PostHogUnity
             Action<string, int> onComplete
         )
         {
-            using var request = CreateFlagsRequest(
-                _config.ApiKey,
-                _config.Host,
-                distinctId,
-                anonymousId,
-                groups,
-                personProperties,
-                groupProperties
-            );
-
-            PostHogLogger.Debug($"Fetching feature flags from {request.url}");
-
-            yield return request.SendWebRequest();
-
-            int statusCode = (int)request.responseCode;
-
-            if (request.result == UnityWebRequest.Result.Success)
+            for (var attempt = 1; attempt <= FeatureFlagsMaxAttempts; attempt++)
             {
-                PostHogLogger.Debug($"Feature flags fetched successfully (status: {statusCode})");
-                onComplete?.Invoke(request.downloadHandler.text, statusCode);
-            }
-            else
-            {
-                PostHogLogger.Warning(
-                    $"Feature flags fetch failed: {request.error} (status: {statusCode})"
-                );
-                onComplete?.Invoke(null, statusCode);
+                using (var request = CreateFlagsRequest(
+                    _config.ApiKey,
+                    _config.Host,
+                    distinctId,
+                    anonymousId,
+                    groups,
+                    personProperties,
+                    groupProperties
+                ))
+                {
+                    PostHogLogger.Debug($"Fetching feature flags from {request.url}");
+
+                    yield return request.SendWebRequest();
+
+                    int statusCode = (int)request.responseCode;
+
+                    if (request.result == UnityWebRequest.Result.Success)
+                    {
+                        PostHogLogger.Debug(
+                            $"Feature flags fetched successfully (status: {statusCode})"
+                        );
+                        onComplete?.Invoke(request.downloadHandler.text, statusCode);
+                        yield break;
+                    }
+
+                    if (
+                        !ShouldRetryFeatureFlagsRequest(request.result, statusCode)
+                        || attempt == FeatureFlagsMaxAttempts
+                    )
+                    {
+                        PostHogLogger.Warning(
+                            $"Feature flags fetch failed: {request.error} (status: {statusCode})"
+                        );
+                        onComplete?.Invoke(null, statusCode);
+                        yield break;
+                    }
+
+                    PostHogLogger.Warning(
+                        $"Feature flags fetch failed: {request.error} (status: {statusCode}); retrying ({attempt}/{FeatureFlagsMaxAttempts})"
+                    );
+                }
+
+                yield return new WaitForSeconds(GetFeatureFlagsRetryDelaySeconds(attempt));
             }
         }
 
@@ -107,6 +127,19 @@ namespace PostHogUnity
         {
             var host = _config.Host.TrimEnd('/');
             return $"{host}/batch";
+        }
+
+        internal static bool ShouldRetryFeatureFlagsRequest(
+            UnityWebRequest.Result result,
+            int statusCode
+        )
+        {
+            return result == UnityWebRequest.Result.ConnectionError && statusCode == 0;
+        }
+
+        static float GetFeatureFlagsRetryDelaySeconds(int failedAttempt)
+        {
+            return FeatureFlagsInitialRetryDelaySeconds * (1 << (failedAttempt - 1));
         }
 
         /// <summary>

--- a/com.posthog.unity/Runtime/Core/NetworkClient.cs
+++ b/com.posthog.unity/Runtime/Core/NetworkClient.cs
@@ -13,12 +13,49 @@ namespace PostHogUnity
     class NetworkClient
     {
         readonly PostHogConfig _config;
+        readonly FeatureFlagsRequestFactory _featureFlagsRequestFactory;
+        readonly FeatureFlagsRetryDelayFactory _featureFlagsRetryDelayFactory;
         const int TimeoutSeconds = 10;
         const float FeatureFlagsInitialRetryDelaySeconds = 0.5f;
 
+        internal delegate IFeatureFlagsRequest FeatureFlagsRequestFactory(
+            string apiKey,
+            string host,
+            string distinctId,
+            string anonymousId,
+            Dictionary<string, string> groups,
+            IReadOnlyDictionary<string, object> personProperties,
+            Dictionary<string, Dictionary<string, object>> groupProperties
+        );
+
+        internal delegate object FeatureFlagsRetryDelayFactory(int failedAttempt);
+
+        internal interface IFeatureFlagsRequest : IDisposable
+        {
+            string Url { get; }
+            UnityWebRequest.Result Result { get; }
+            long ResponseCode { get; }
+            string Error { get; }
+            string Text { get; }
+            object Send();
+        }
+
         public NetworkClient(PostHogConfig config)
+            : this(
+                config,
+                CreateFeatureFlagsRequest,
+                failedAttempt => new WaitForSeconds(GetFeatureFlagsRetryDelaySeconds(failedAttempt))
+            ) { }
+
+        internal NetworkClient(
+            PostHogConfig config,
+            FeatureFlagsRequestFactory featureFlagsRequestFactory,
+            FeatureFlagsRetryDelayFactory featureFlagsRetryDelayFactory
+        )
         {
             _config = config;
+            _featureFlagsRequestFactory = featureFlagsRequestFactory;
+            _featureFlagsRetryDelayFactory = featureFlagsRetryDelayFactory;
         }
 
         /// <summary>
@@ -77,49 +114,51 @@ namespace PostHogUnity
             var maxAttempts = Math.Max(1, _config.FeatureFlagRequestMaxRetries + 1);
             for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
-                using (var request = CreateFlagsRequest(
-                    _config.ApiKey,
-                    _config.Host,
-                    distinctId,
-                    anonymousId,
-                    groups,
-                    personProperties,
-                    groupProperties
-                ))
+                using (
+                    var request = _featureFlagsRequestFactory(
+                        _config.ApiKey,
+                        _config.Host,
+                        distinctId,
+                        anonymousId,
+                        groups,
+                        personProperties,
+                        groupProperties
+                    )
+                )
                 {
-                    PostHogLogger.Debug($"Fetching feature flags from {request.url}");
+                    PostHogLogger.Debug($"Fetching feature flags from {request.Url}");
 
-                    yield return request.SendWebRequest();
+                    yield return request.Send();
 
-                    int statusCode = (int)request.responseCode;
+                    int statusCode = (int)request.ResponseCode;
 
-                    if (request.result == UnityWebRequest.Result.Success)
+                    if (request.Result == UnityWebRequest.Result.Success)
                     {
                         PostHogLogger.Debug(
                             $"Feature flags fetched successfully (status: {statusCode})"
                         );
-                        onComplete?.Invoke(request.downloadHandler.text, statusCode);
+                        onComplete?.Invoke(request.Text, statusCode);
                         yield break;
                     }
 
                     if (
-                        !ShouldRetryFeatureFlagsRequest(request.result, statusCode, request.error)
+                        !ShouldRetryFeatureFlagsRequest(request.Result, statusCode, request.Error)
                         || attempt == maxAttempts
                     )
                     {
                         PostHogLogger.Warning(
-                            $"Feature flags fetch failed: {request.error} (status: {statusCode})"
+                            $"Feature flags fetch failed: {request.Error} (status: {statusCode})"
                         );
                         onComplete?.Invoke(null, statusCode);
                         yield break;
                     }
 
                     PostHogLogger.Warning(
-                        $"Feature flags fetch failed: {request.error} (status: {statusCode}); retrying ({attempt}/{maxAttempts})"
+                        $"Feature flags fetch failed: {request.Error} (status: {statusCode}); retrying ({attempt}/{maxAttempts})"
                     );
                 }
 
-                yield return new WaitForSeconds(GetFeatureFlagsRetryDelaySeconds(attempt));
+                yield return _featureFlagsRetryDelayFactory(attempt);
             }
         }
 
@@ -147,15 +186,64 @@ namespace PostHogUnity
 
             var lowerError = error.ToLowerInvariant();
             return lowerError.Contains("timeout")
-                   || lowerError.Contains("timed out")
-                   || lowerError.Contains("reset")
-                   || lowerError.Contains("eof")
-                   || lowerError.Contains("connection lost");
+                || lowerError.Contains("timed out")
+                || lowerError.Contains("reset")
+                || lowerError.Contains("eof")
+                || lowerError.Contains("connection lost");
         }
 
         static float GetFeatureFlagsRetryDelaySeconds(int failedAttempt)
         {
             return FeatureFlagsInitialRetryDelaySeconds * (1 << (failedAttempt - 1));
+        }
+
+        static IFeatureFlagsRequest CreateFeatureFlagsRequest(
+            string apiKey,
+            string host,
+            string distinctId,
+            string anonymousId,
+            Dictionary<string, string> groups,
+            IReadOnlyDictionary<string, object> personProperties,
+            Dictionary<string, Dictionary<string, object>> groupProperties
+        )
+        {
+            return new UnityWebRequestFeatureFlagsRequest(
+                CreateFlagsRequest(
+                    apiKey,
+                    host,
+                    distinctId,
+                    anonymousId,
+                    groups,
+                    personProperties,
+                    groupProperties
+                )
+            );
+        }
+
+        sealed class UnityWebRequestFeatureFlagsRequest : IFeatureFlagsRequest
+        {
+            readonly UnityWebRequest _request;
+
+            public UnityWebRequestFeatureFlagsRequest(UnityWebRequest request)
+            {
+                _request = request;
+            }
+
+            public string Url => _request.url;
+            public UnityWebRequest.Result Result => _request.result;
+            public long ResponseCode => _request.responseCode;
+            public string Error => _request.error;
+            public string Text => _request.downloadHandler.text;
+
+            public object Send()
+            {
+                return _request.SendWebRequest();
+            }
+
+            public void Dispose()
+            {
+                _request.Dispose();
+            }
         }
 
         /// <summary>

--- a/com.posthog.unity/Runtime/Core/NetworkClient.cs
+++ b/com.posthog.unity/Runtime/Core/NetworkClient.cs
@@ -14,7 +14,6 @@ namespace PostHogUnity
     {
         readonly PostHogConfig _config;
         const int TimeoutSeconds = 10;
-        const int FeatureFlagsMaxAttempts = 3;
         const float FeatureFlagsInitialRetryDelaySeconds = 0.5f;
 
         public NetworkClient(PostHogConfig config)
@@ -75,7 +74,8 @@ namespace PostHogUnity
             Action<string, int> onComplete
         )
         {
-            for (var attempt = 1; attempt <= FeatureFlagsMaxAttempts; attempt++)
+            var maxAttempts = Math.Max(1, _config.FeatureFlagRequestMaxRetries + 1);
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
                 using (var request = CreateFlagsRequest(
                     _config.ApiKey,
@@ -104,7 +104,7 @@ namespace PostHogUnity
 
                     if (
                         !ShouldRetryFeatureFlagsRequest(request.result, statusCode, request.error)
-                        || attempt == FeatureFlagsMaxAttempts
+                        || attempt == maxAttempts
                     )
                     {
                         PostHogLogger.Warning(
@@ -115,7 +115,7 @@ namespace PostHogUnity
                     }
 
                     PostHogLogger.Warning(
-                        $"Feature flags fetch failed: {request.error} (status: {statusCode}); retrying ({attempt}/{FeatureFlagsMaxAttempts})"
+                        $"Feature flags fetch failed: {request.error} (status: {statusCode}); retrying ({attempt}/{maxAttempts})"
                     );
                 }
 

--- a/com.posthog.unity/Runtime/Core/NetworkClient.cs
+++ b/com.posthog.unity/Runtime/Core/NetworkClient.cs
@@ -16,7 +16,7 @@ namespace PostHogUnity
         readonly FeatureFlagsRequestFactory _featureFlagsRequestFactory;
         readonly FeatureFlagsRetryDelayFactory _featureFlagsRetryDelayFactory;
         const int TimeoutSeconds = 10;
-        const float FeatureFlagsInitialRetryDelaySeconds = 0.5f;
+        const float FeatureFlagsInitialRetryDelaySeconds = 0.3f;
 
         internal delegate IFeatureFlagsRequest FeatureFlagsRequestFactory(
             string apiKey,
@@ -192,7 +192,7 @@ namespace PostHogUnity
                 || lowerError.Contains("connection lost");
         }
 
-        static float GetFeatureFlagsRetryDelaySeconds(int failedAttempt)
+        internal static float GetFeatureFlagsRetryDelaySeconds(int failedAttempt)
         {
             return FeatureFlagsInitialRetryDelaySeconds * (1 << (failedAttempt - 1));
         }

--- a/com.posthog.unity/Runtime/PostHogConfig.cs
+++ b/com.posthog.unity/Runtime/PostHogConfig.cs
@@ -82,6 +82,12 @@ namespace PostHogUnity
         public bool PreloadFeatureFlags { get; set; } = true;
 
         /// <summary>
+        /// Maximum number of retries for feature flag requests after transient network errors.
+        /// Defaults to 1. Set to 0 to disable feature flag request retries.
+        /// </summary>
+        public int FeatureFlagRequestMaxRetries { get; set; } = 1;
+
+        /// <summary>
         /// Whether to send $feature_flag_called events when flags are accessed.
         /// Required for experiments and A/B test tracking.
         /// Defaults to true.

--- a/com.posthog.unity/Runtime/PostHogSettings.cs
+++ b/com.posthog.unity/Runtime/PostHogSettings.cs
@@ -89,6 +89,11 @@ namespace PostHogUnity
         [SerializeField]
         bool _preloadFeatureFlags = true;
 
+        [Tooltip("Maximum number of retries for feature flag requests after transient network errors. Set to 0 to disable.")]
+        [Min(0)]
+        [SerializeField]
+        int _featureFlagRequestMaxRetries = 1;
+
         [Tooltip(
             "Whether to send $feature_flag_called events when flags are accessed. "
                 + "Required for experiments and A/B test tracking."
@@ -182,6 +187,11 @@ namespace PostHogUnity
         public bool PreloadFeatureFlags => _preloadFeatureFlags;
 
         /// <summary>
+        /// Maximum number of retries for feature flag requests after transient network errors.
+        /// </summary>
+        public int FeatureFlagRequestMaxRetries => _featureFlagRequestMaxRetries;
+
+        /// <summary>
         /// Whether to send $feature_flag_called events when flags are accessed.
         /// </summary>
         public bool SendFeatureFlagEvent => _sendFeatureFlagEvent;
@@ -234,6 +244,7 @@ namespace PostHogUnity
                 LogLevel = _logLevel,
                 ReuseAnonymousId = _reuseAnonymousId,
                 PreloadFeatureFlags = _preloadFeatureFlags,
+                FeatureFlagRequestMaxRetries = _featureFlagRequestMaxRetries,
                 SendFeatureFlagEvent = _sendFeatureFlagEvent,
                 SendDefaultPersonPropertiesForFlags = _sendDefaultPersonPropertiesForFlags,
                 CaptureExceptions = _captureExceptions,
@@ -251,6 +262,7 @@ namespace PostHogUnity
             _flushIntervalSeconds = Mathf.Max(1, _flushIntervalSeconds);
             _maxQueueSize = Mathf.Max(1, _maxQueueSize);
             _maxBatchSize = Mathf.Max(1, _maxBatchSize);
+            _featureFlagRequestMaxRetries = Mathf.Max(0, _featureFlagRequestMaxRetries);
             _exceptionDebounceIntervalMs = Mathf.Max(0, _exceptionDebounceIntervalMs);
         }
     }

--- a/com.posthog.unity/Runtime/PostHogSettings.cs
+++ b/com.posthog.unity/Runtime/PostHogSettings.cs
@@ -89,7 +89,9 @@ namespace PostHogUnity
         [SerializeField]
         bool _preloadFeatureFlags = true;
 
-        [Tooltip("Maximum number of retries for feature flag requests after transient network errors. Set to 0 to disable.")]
+        [Tooltip(
+            "Maximum number of retries for feature flag requests after transient network errors. Set to 0 to disable."
+        )]
         [Min(0)]
         [SerializeField]
         int _featureFlagRequestMaxRetries = 1;

--- a/tests/PostHog.Unity.Tests/NetworkClientTests.cs
+++ b/tests/PostHog.Unity.Tests/NetworkClientTests.cs
@@ -72,6 +72,20 @@ namespace PostHogUnity.Tests
 
                 Assert.False(shouldRetry);
             }
+
+            [Theory]
+            [InlineData(1, 0.3)]
+            [InlineData(2, 0.6)]
+            [InlineData(3, 1.2)]
+            public void DoublesRetryDelayFromThreeHundredMilliseconds(
+                int failedAttempt,
+                double expectedDelaySeconds
+            )
+            {
+                var delaySeconds = NetworkClient.GetFeatureFlagsRetryDelaySeconds(failedAttempt);
+
+                Assert.Equal(expectedDelaySeconds, delaySeconds, precision: 3);
+            }
         }
 
         public class TheFetchFeatureFlagsRetryLoop

--- a/tests/PostHog.Unity.Tests/NetworkClientTests.cs
+++ b/tests/PostHog.Unity.Tests/NetworkClientTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using PostHogUnity;
 using UnityEngine.Networking;
 
@@ -70,6 +71,181 @@ namespace PostHogUnity.Tests
                 );
 
                 Assert.False(shouldRetry);
+            }
+        }
+
+        public class TheFetchFeatureFlagsRetryLoop
+        {
+            [Fact]
+            public void RetriesTransientConnectionErrorsUntilSuccess()
+            {
+                var requests = new Queue<FakeFeatureFlagsRequest>(
+                    new[]
+                    {
+                        FakeFeatureFlagsRequest.ConnectionError("Connection reset by peer"),
+                        FakeFeatureFlagsRequest.ConnectionError("EOF"),
+                        FakeFeatureFlagsRequest.Success("{\"featureFlags\":{}}", 200),
+                    }
+                );
+                var sentRequests = new List<FakeFeatureFlagsRequest>();
+                var client = CreateRetryClient(2, requests, sentRequests);
+                string response = null;
+                var statusCode = 0;
+                var completions = 0;
+
+                RunCoroutine(
+                    client.FetchFeatureFlags(
+                        "user-1",
+                        null,
+                        null,
+                        null,
+                        null,
+                        (json, status) =>
+                        {
+                            completions++;
+                            response = json;
+                            statusCode = status;
+                        }
+                    )
+                );
+
+                Assert.Equal(3, sentRequests.Count);
+                Assert.All(sentRequests, request => Assert.True(request.WasSent));
+                Assert.Equal(1, completions);
+                Assert.Equal("{\"featureFlags\":{}}", response);
+                Assert.Equal(200, statusCode);
+            }
+
+            [Fact]
+            public void ReportsNullOnlyAfterTransientRetriesAreExhausted()
+            {
+                var requests = new Queue<FakeFeatureFlagsRequest>(
+                    new[]
+                    {
+                        FakeFeatureFlagsRequest.ConnectionError("Connection reset by peer"),
+                        FakeFeatureFlagsRequest.ConnectionError("request timed out"),
+                        FakeFeatureFlagsRequest.ConnectionError("connection lost"),
+                    }
+                );
+                var sentRequests = new List<FakeFeatureFlagsRequest>();
+                var client = CreateRetryClient(2, requests, sentRequests);
+                string response = "not completed";
+                var statusCode = -1;
+                var completions = 0;
+
+                RunCoroutine(
+                    client.FetchFeatureFlags(
+                        "user-1",
+                        null,
+                        null,
+                        null,
+                        null,
+                        (json, status) =>
+                        {
+                            completions++;
+                            response = json;
+                            statusCode = status;
+                        }
+                    )
+                );
+
+                Assert.Equal(3, sentRequests.Count);
+                Assert.All(sentRequests, request => Assert.True(request.WasSent));
+                Assert.Equal(1, completions);
+                Assert.Null(response);
+                Assert.Equal(0, statusCode);
+            }
+
+            static NetworkClient CreateRetryClient(
+                int maxRetries,
+                Queue<FakeFeatureFlagsRequest> requests,
+                List<FakeFeatureFlagsRequest> sentRequests
+            )
+            {
+                return new NetworkClient(
+                    new PostHogConfig
+                    {
+                        ApiKey = "test-api-key",
+                        Host = "https://example.com",
+                        FeatureFlagRequestMaxRetries = maxRetries,
+                    },
+                    (_, _, _, _, _, _, _) =>
+                    {
+                        var request = requests.Dequeue();
+                        sentRequests.Add(request);
+                        return request;
+                    },
+                    _ => EmptyCoroutine()
+                );
+            }
+
+            static void RunCoroutine(IEnumerator coroutine)
+            {
+                while (coroutine.MoveNext())
+                {
+                    if (coroutine.Current is IEnumerator nestedCoroutine)
+                    {
+                        RunCoroutine(nestedCoroutine);
+                    }
+                }
+            }
+
+            static IEnumerator EmptyCoroutine()
+            {
+                yield break;
+            }
+
+            sealed class FakeFeatureFlagsRequest : NetworkClient.IFeatureFlagsRequest
+            {
+                readonly string _text;
+
+                FakeFeatureFlagsRequest(
+                    UnityWebRequest.Result result,
+                    long responseCode,
+                    string error,
+                    string text
+                )
+                {
+                    Result = result;
+                    ResponseCode = responseCode;
+                    Error = error;
+                    _text = text;
+                }
+
+                public string Url => "https://example.com/flags";
+                public UnityWebRequest.Result Result { get; }
+                public long ResponseCode { get; }
+                public string Error { get; }
+                public string Text => _text;
+                public bool WasSent { get; private set; }
+
+                public static FakeFeatureFlagsRequest ConnectionError(string error)
+                {
+                    return new FakeFeatureFlagsRequest(
+                        UnityWebRequest.Result.ConnectionError,
+                        0,
+                        error,
+                        null
+                    );
+                }
+
+                public static FakeFeatureFlagsRequest Success(string text, long responseCode)
+                {
+                    return new FakeFeatureFlagsRequest(
+                        UnityWebRequest.Result.Success,
+                        responseCode,
+                        null,
+                        text
+                    );
+                }
+
+                public object Send()
+                {
+                    WasSent = true;
+                    return EmptyCoroutine();
+                }
+
+                public void Dispose() { }
             }
         }
     }

--- a/tests/PostHog.Unity.Tests/NetworkClientTests.cs
+++ b/tests/PostHog.Unity.Tests/NetworkClientTests.cs
@@ -8,14 +8,27 @@ namespace PostHogUnity.Tests
         public class TheFeatureFlagsRetryPolicy
         {
             [Fact]
-            public void RetriesConnectionErrorsWithoutHttpStatus()
+            public void RetriesTransientConnectionErrorsWithoutHttpStatus()
             {
                 var shouldRetry = NetworkClient.ShouldRetryFeatureFlagsRequest(
                     UnityWebRequest.Result.ConnectionError,
-                    0
+                    0,
+                    "Connection reset by peer"
                 );
 
                 Assert.True(shouldRetry);
+            }
+
+            [Fact]
+            public void DoesNotRetryConnectionRefused()
+            {
+                var shouldRetry = NetworkClient.ShouldRetryFeatureFlagsRequest(
+                    UnityWebRequest.Result.ConnectionError,
+                    0,
+                    "Cannot connect to destination host"
+                );
+
+                Assert.False(shouldRetry);
             }
 
             [Theory]

--- a/tests/PostHog.Unity.Tests/NetworkClientTests.cs
+++ b/tests/PostHog.Unity.Tests/NetworkClientTests.cs
@@ -1,0 +1,63 @@
+using PostHogUnity;
+using UnityEngine.Networking;
+
+namespace PostHogUnity.Tests
+{
+    public class NetworkClientTests
+    {
+        public class TheFeatureFlagsRetryPolicy
+        {
+            [Fact]
+            public void RetriesConnectionErrorsWithoutHttpStatus()
+            {
+                var shouldRetry = NetworkClient.ShouldRetryFeatureFlagsRequest(
+                    UnityWebRequest.Result.ConnectionError,
+                    0
+                );
+
+                Assert.True(shouldRetry);
+            }
+
+            [Theory]
+            [InlineData(408)]
+            [InlineData(429)]
+            [InlineData(500)]
+            [InlineData(503)]
+            public void DoesNotRetryHttpStatusErrors(int statusCode)
+            {
+                var shouldRetry = NetworkClient.ShouldRetryFeatureFlagsRequest(
+                    UnityWebRequest.Result.ProtocolError,
+                    statusCode
+                );
+
+                Assert.False(shouldRetry);
+            }
+
+            [Theory]
+            [InlineData(408)]
+            [InlineData(429)]
+            [InlineData(500)]
+            [InlineData(503)]
+            public void DoesNotRetryConnectionErrorsWithHttpStatus(int statusCode)
+            {
+                var shouldRetry = NetworkClient.ShouldRetryFeatureFlagsRequest(
+                    UnityWebRequest.Result.ConnectionError,
+                    statusCode
+                );
+
+                Assert.False(shouldRetry);
+            }
+
+            [Fact]
+            public void DoesNotRetryDataProcessingErrors()
+            {
+                var shouldRetry = NetworkClient.ShouldRetryFeatureFlagsRequest(
+                    UnityWebRequest.Result.DataProcessingError,
+                    0
+                );
+
+                Assert.False(shouldRetry);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

`/flags/?v=2` evaluation should tolerate transient network failures, but should not retry HTTP/API responses such as 408, 429, or 5xx.

This PR adds bounded retry/backoff only for transient network failures (timeouts, connection resets/lost connections, and EOF-style failures) and keeps HTTP/API status errors terminal.

## :green_heart: How did you test it?

See the repo-specific command below.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by pi after a maintainer-directed cross-SDK pass. The chosen policy is transient network-only retry/backoff for `/flags/?v=2`; HTTP/API statuses remain non-retryable by design. Connection-refused failures also fail fast where the platform exposes that distinction.

Tested with:

```bash
dotnet test tests/PostHog.Unity.Tests/PostHog.Unity.Tests.csproj --filter NetworkClientTests
```
