### PR TITLE
ci: Run SDK compliance as client capture suite

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,8 +14,11 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@fix/sdk-harness-options-20260630
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
       test-harness-version: "0.8.0"
+      suite: "capture"
+      sdk-type: "client"
+      continue-on-error: true

--- a/sdk_compliance_adapter/Program.cs
+++ b/sdk_compliance_adapter/Program.cs
@@ -110,6 +110,8 @@ sealed class AdapterState : IDisposable
     {
         var uuid = Guid.NewGuid().ToString();
         var properties = request.Properties?.ToDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value) ?? new Dictionary<string, object?>();
+        properties["distinct_id"] = request.DistinctId ?? "";
+        properties["token"] = _apiKey;
         properties["$lib"] = Constants.SdkName;
         properties["$lib_version"] = Constants.SdkVersion;
 

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   test-harness:
     image: ghcr.io/posthog/sdk-test-harness:0.8.0
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "server", "--debug"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "client", "--suite", "capture", "--debug"]
     networks:
       - test-network
     depends_on:


### PR DESCRIPTION
## Problem

SDK compliance workflows need explicit harness suite/sdk-type selection and configurable blocking behavior so CI only runs the intended contract checks.

## Changes

- Point SDK compliance to the harness branch with new workflow inputs.
- Run capture v0 as a client SDK.
- Include client-shaped `distinct_id` and `token` properties in compliance adapter events.
- Keep failures non-blocking for now and align local compose with the same suite/sdk type.

## Testing

- Parsed workflow YAML.
- Ran `dotnet build sdk_compliance_adapter/PostHog.Unity.ComplianceAdapter.csproj --no-restore`.
- Ran `docker compose config` for the adapter compose file.
- Ran `git diff --check`.

## Release / changeset

No SDK package changeset: only compliance adapter/config changed, not the published Unity SDK package.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using dedicated git worktrees. The change was requested to align SDK compliance harness setup across SDK repositories while keeping non-ready SDKs non-blocking.
