### PR TITLE
ci: skip heavy CI for non-impacting changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,24 +21,207 @@ env:
 permissions:
   checks: write
   contents: read
+  pull-requests: read
 
 jobs:
+  skip_heavy:
+    runs-on: ubuntu-latest
+    outputs:
+      skip_heavy: ${{ steps.classify.outputs.skip_heavy }}
+      reason: ${{ steps.classify.outputs.reason }}
+    steps:
+      - name: Classify changed files
+        id: classify
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          set_result() {
+            local skip_heavy="$1"
+            local reason="$2"
+
+            {
+              echo "skip_heavy=${skip_heavy}"
+              echo "reason=${reason}"
+            } >> "$GITHUB_OUTPUT"
+
+            {
+              echo "### Heavy CI classifier"
+              echo "- skip_heavy: \`${skip_heavy}\`"
+              echo "- reason: ${reason}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          run_full() {
+            set_result "false" "$1"
+          }
+
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            run_full "full CI runs for ${EVENT_NAME} events"
+            exit 0
+          fi
+
+          if [[ -z "${PR_NUMBER:-}" ]]; then
+            run_full "pull request number unavailable; running full CI"
+            exit 0
+          fi
+
+          changed_files_file="$(mktemp)"
+          trap 'rm -f "$changed_files_file"' EXIT
+
+          page=1
+          while true; do
+            url="${API_URL}/repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}"
+            if ! page_json="$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$url")"; then
+              run_full "could not list pull request files; running full CI"
+              exit 0
+            fi
+
+            if ! page_count="$(jq 'length' <<< "$page_json")"; then
+              run_full "could not parse pull request files; running full CI"
+              exit 0
+            fi
+
+            if ! jq -r '.[] | (.filename, .previous_filename? // empty) | select(type == "string" and length > 0)' <<< "$page_json" >> "$changed_files_file"; then
+              run_full "could not read pull request filenames; running full CI"
+              exit 0
+            fi
+
+            if (( page_count < 100 )); then
+              break
+            fi
+
+            page=$((page + 1))
+          done
+
+          mapfile -t changed_files < <(sort -u "$changed_files_file")
+
+          if (( ${#changed_files[@]} == 0 )); then
+            run_full "no changed files found; running full CI"
+            exit 0
+          fi
+
+          is_skippable_file() {
+            local file="$1"
+
+            case "$file" in
+              *.md|\
+              docs/*|\
+              .github/ISSUE_TEMPLATE/*|\
+              .github/PULL_REQUEST_TEMPLATE/*|\
+              .github/pull_request_template.md|\
+              .github/CODEOWNERS|\
+              CODEOWNERS|\
+              .github/dependabot.yml|\
+              .github/workflows/release.yml|\
+              .github/workflows/release.yaml|\
+              .github/workflows/publish.yml|\
+              .github/workflows/publish.yaml|\
+              .github/workflows/stale.yml|\
+              .github/workflows/stale.yaml|\
+              .github/workflows/lint-pr.yml|\
+              .github/workflows/lint-pr.yaml|\
+              .github/workflows/call-flags-project-board.yml|\
+              .github/workflows/call-flags-project-board.yaml|\
+              .github/workflows/changeset-hygiene.yml|\
+              .github/workflows/changeset-hygiene.yaml|\
+              .github/workflows/dependabot-changeset.yml|\
+              .github/workflows/dependabot-changeset.yaml|\
+              .github/workflows/validate-versioning.yml|\
+              .github/workflows/validate-versioning.yaml|\
+              .github/workflows/new-pr.yml|\
+              .github/workflows/new-pr.yaml|\
+              .github/workflows/generated-files-notice.yml|\
+              .github/workflows/generated-files-notice.yaml|\
+              .github/workflows/posthog-upgrade.yml|\
+              .github/workflows/posthog-upgrade.yaml|\
+              .github/workflows/posthog-watcher-*.yml|\
+              .github/workflows/posthog-watcher-*.yaml)
+                return 0
+                ;;
+            esac
+
+            return 1
+          }
+
+          non_skippable_files=()
+          for file in "${changed_files[@]}"; do
+            if ! is_skippable_file "$file"; then
+              non_skippable_files+=("$file")
+            fi
+          done
+
+          {
+            echo ""
+            echo "<details>"
+            echo "<summary>Changed files</summary>"
+            echo ""
+            for file in "${changed_files[@]}"; do
+              printf -- '- `%s`\n' "$file"
+            done
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if (( ${#non_skippable_files[@]} == 0 )); then
+            set_result "true" "only globally safe documentation, template, metadata, or non-CI workflow files changed"
+            exit 0
+          fi
+
+          sample="${non_skippable_files[0]}"
+          for file in "${non_skippable_files[@]:1:9}"; do
+            sample+=", ${file}"
+          done
+
+          if (( ${#non_skippable_files[@]} > 10 )); then
+            sample+=", ..."
+          fi
+
+          run_full "non-skippable changes detected: ${sample}"
+
   build:
     runs-on: ubuntu-latest
+    needs: skip_heavy
+    if: ${{ always() }}
     steps:
+      - name: Skip build
+        if: ${{ needs.skip_heavy.result == 'success' && needs.skip_heavy.outputs.skip_heavy == 'true' }}
+        shell: bash
+        env:
+          SKIP_REASON: ${{ needs.skip_heavy.outputs.reason }}
+        run: |
+          echo "Skipping build: ${SKIP_REASON}"
+          {
+            echo "### Build skipped"
+            echo "${SKIP_REASON}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Build package
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         run: ./bin/build
         shell: bash
 
       - name: Check public API
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         # If this fails because the public API changed intentionally, regenerate the baseline with:
         # ./bin/check-public-api --update
         run: ./bin/check-public-api
@@ -46,30 +229,64 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs: skip_heavy
+    if: ${{ always() }}
     steps:
+      - name: Skip tests
+        if: ${{ needs.skip_heavy.result == 'success' && needs.skip_heavy.outputs.skip_heavy == 'true' }}
+        shell: bash
+        env:
+          SKIP_REASON: ${{ needs.skip_heavy.outputs.reason }}
+        run: |
+          echo "Skipping tests: ${SKIP_REASON}"
+          {
+            echo "### Tests skipped"
+            echo "${SKIP_REASON}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Run Tests
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         run: ./bin/test
         shell: bash
 
   format:
     runs-on: ubuntu-latest
+    needs: skip_heavy
+    if: ${{ always() }}
     steps:
+      - name: Skip format
+        if: ${{ needs.skip_heavy.result == 'success' && needs.skip_heavy.outputs.skip_heavy == 'true' }}
+        shell: bash
+        env:
+          SKIP_REASON: ${{ needs.skip_heavy.outputs.reason }}
+        run: |
+          echo "Skipping format: ${SKIP_REASON}"
+          {
+            echo "### Format skipped"
+            echo "${SKIP_REASON}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Check Formatting
+        if: ${{ needs.skip_heavy.result != 'success' || needs.skip_heavy.outputs.skip_heavy != 'true' }}
         run: ./bin/fmt --check
         shell: bash


### PR DESCRIPTION
## Summary
- add a lightweight `skip_heavy` classifier to the required CI workflow
- keep required `build`, `test`, and `format` job contexts while no-oping those jobs for PRs whose changed `filename` and `previous_filename` entries are all in the generic globally safe set
- use only global safe patterns: Markdown/docs, issue/PR templates, CODEOWNERS, Dependabot config, and selected non-CI maintenance workflows
- default to full CI for pushes, classifier/API failures, empty change lists, CI/current workflow changes, source/test/build/config/package/lockfile changes, and unknown files

## Validation
- `python3` YAML parse of `.github/workflows/ci.yml` and embedded classifier extraction
- `bash -n /tmp/posthog-unity-ci-classifier.sh`
- classifier harness cases for Markdown/docs/templates/CODEOWNERS/Dependabot/allowed workflows, current CI workflow, source, tests, package/lock/config, unknown files, and rename `previous_filename` handling
- `jq` sample extraction confirmed both `filename` and `previous_filename` are evaluated
- `git diff --check`
