### PR TITLE
fix: Retry flags requests on 502 and 504

### DIFF
--- a/.changeset/gentle-flags-retry.md
+++ b/.changeset/gentle-flags-retry.md
@@ -1,0 +1,5 @@
+---
+'com.posthog.unity': patch
+---
+
+Retry remote feature flag requests after transient 502 and 504 responses.

--- a/com.posthog.unity/Runtime/Core/NetworkClient.cs
+++ b/com.posthog.unity/Runtime/Core/NetworkClient.cs
@@ -174,6 +174,14 @@ namespace PostHogUnity
             string error = null
         )
         {
+            if (
+                result == UnityWebRequest.Result.ProtocolError
+                && IsRetryableFeatureFlagsStatusCode(statusCode)
+            )
+            {
+                return true;
+            }
+
             if (result != UnityWebRequest.Result.ConnectionError || statusCode != 0)
             {
                 return false;
@@ -190,6 +198,11 @@ namespace PostHogUnity
                 || lowerError.Contains("reset")
                 || lowerError.Contains("eof")
                 || lowerError.Contains("connection lost");
+        }
+
+        static bool IsRetryableFeatureFlagsStatusCode(int statusCode)
+        {
+            return statusCode == 502 || statusCode == 504;
         }
 
         internal static float GetFeatureFlagsRetryDelaySeconds(int failedAttempt)

--- a/tests/PostHog.Unity.Tests/NetworkClientTests.cs
+++ b/tests/PostHog.Unity.Tests/NetworkClientTests.cs
@@ -33,11 +33,24 @@ namespace PostHogUnity.Tests
             }
 
             [Theory]
+            [InlineData(502)]
+            [InlineData(504)]
+            public void RetriesRetryableHttpStatusErrors(int statusCode)
+            {
+                var shouldRetry = NetworkClient.ShouldRetryFeatureFlagsRequest(
+                    UnityWebRequest.Result.ProtocolError,
+                    statusCode
+                );
+
+                Assert.True(shouldRetry);
+            }
+
+            [Theory]
             [InlineData(408)]
             [InlineData(429)]
             [InlineData(500)]
             [InlineData(503)]
-            public void DoesNotRetryHttpStatusErrors(int statusCode)
+            public void DoesNotRetryOtherHttpStatusErrors(int statusCode)
             {
                 var shouldRetry = NetworkClient.ShouldRetryFeatureFlagsRequest(
                     UnityWebRequest.Result.ProtocolError,
@@ -51,7 +64,9 @@ namespace PostHogUnity.Tests
             [InlineData(408)]
             [InlineData(429)]
             [InlineData(500)]
+            [InlineData(502)]
             [InlineData(503)]
+            [InlineData(504)]
             public void DoesNotRetryConnectionErrorsWithHttpStatus(int statusCode)
             {
                 var shouldRetry = NetworkClient.ShouldRetryFeatureFlagsRequest(
@@ -127,6 +142,53 @@ namespace PostHogUnity.Tests
                 Assert.All(sentRequests, request => Assert.True(request.WasSent));
                 Assert.Equal(1, completions);
                 Assert.Equal("{\"featureFlags\":{}}", response);
+                Assert.Equal(200, statusCode);
+            }
+
+            [Theory]
+            [InlineData(502)]
+            [InlineData(504)]
+            public void RetriesRetryableHttpStatusErrorsUntilSuccess(int retryableStatusCode)
+            {
+                var requests = new Queue<FakeFeatureFlagsRequest>(
+                    new[]
+                    {
+                        FakeFeatureFlagsRequest.ProtocolError(
+                            "HTTP status error",
+                            retryableStatusCode
+                        ),
+                        FakeFeatureFlagsRequest.Success(
+                            "{\"featureFlags\":{\"example\":true}}",
+                            200
+                        ),
+                    }
+                );
+                var sentRequests = new List<FakeFeatureFlagsRequest>();
+                var client = CreateRetryClient(1, requests, sentRequests);
+                string response = null;
+                var statusCode = 0;
+                var completions = 0;
+
+                RunCoroutine(
+                    client.FetchFeatureFlags(
+                        "user-1",
+                        null,
+                        null,
+                        null,
+                        null,
+                        (json, status) =>
+                        {
+                            completions++;
+                            response = json;
+                            statusCode = status;
+                        }
+                    )
+                );
+
+                Assert.Equal(2, sentRequests.Count);
+                Assert.All(sentRequests, request => Assert.True(request.WasSent));
+                Assert.Equal(1, completions);
+                Assert.Equal("{\"featureFlags\":{\"example\":true}}", response);
                 Assert.Equal(200, statusCode);
             }
 
@@ -250,6 +312,16 @@ namespace PostHogUnity.Tests
                         responseCode,
                         null,
                         text
+                    );
+                }
+
+                public static FakeFeatureFlagsRequest ProtocolError(string error, long responseCode)
+                {
+                    return new FakeFeatureFlagsRequest(
+                        UnityWebRequest.Result.ProtocolError,
+                        responseCode,
+                        error,
+                        null
                     );
                 }
 

--- a/tests/PostHog.Unity.Tests/NetworkClientTests.cs
+++ b/tests/PostHog.Unity.Tests/NetworkClientTests.cs
@@ -232,6 +232,54 @@ namespace PostHogUnity.Tests
                 Assert.Equal(0, statusCode);
             }
 
+            [Theory]
+            [InlineData(502)]
+            [InlineData(504)]
+            public void ReportsNullOnlyAfterRetryableHttpStatusRetriesAreExhausted(
+                int retryableStatusCode
+            )
+            {
+                var maxRetries = 2;
+                var requests = new Queue<FakeFeatureFlagsRequest>();
+                for (var i = 0; i <= maxRetries; i++)
+                {
+                    requests.Enqueue(
+                        FakeFeatureFlagsRequest.ProtocolError(
+                            "HTTP status error",
+                            retryableStatusCode
+                        )
+                    );
+                }
+
+                var sentRequests = new List<FakeFeatureFlagsRequest>();
+                var client = CreateRetryClient(maxRetries, requests, sentRequests);
+                string response = "not completed";
+                var statusCode = -1;
+                var completions = 0;
+
+                RunCoroutine(
+                    client.FetchFeatureFlags(
+                        "user-1",
+                        null,
+                        null,
+                        null,
+                        null,
+                        (json, status) =>
+                        {
+                            completions++;
+                            response = json;
+                            statusCode = status;
+                        }
+                    )
+                );
+
+                Assert.Equal(maxRetries + 1, sentRequests.Count);
+                Assert.All(sentRequests, request => Assert.True(request.WasSent));
+                Assert.Equal(1, completions);
+                Assert.Null(response);
+                Assert.Equal(retryableStatusCode, statusCode);
+            }
+
             static NetworkClient CreateRetryClient(
                 int maxRetries,
                 Queue<FakeFeatureFlagsRequest> requests,


### PR DESCRIPTION
## :bulb: Motivation and Context

Feature flag `/flags` requests already retry selected transient connection failures via `FeatureFlagRequestMaxRetries`, but HTTP 502 and 504 responses were treated as terminal failures. This updates the feature flag retry policy only so gateway errors can retry and recover.

## :green_heart: How did you test it?

- `bin/test --filter "NetworkClientTests"`
- `bin/fmt --check`
- `bin/test`
- `bin/build`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented a narrowly scoped retry policy change for feature flag `/flags` requests. The SDK now retries Unity `ProtocolError` responses with status 502 or 504 while preserving existing transient connection retry behavior and leaving event/replay queue behavior untouched.
