### PR TITLE
fix(compliance): retry feature flag requests

### DIFF
--- a/sdk_compliance_adapter/Program.cs
+++ b/sdk_compliance_adapter/Program.cs
@@ -174,26 +174,7 @@ sealed class AdapterState : IDisposable
             ["flag_keys_to_evaluate"] = new[] { request.Key ?? "" },
         };
 
-        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, $"{_host}/flags/?v=2");
-        httpRequest.Content = JsonContent(body);
-        if (!string.IsNullOrEmpty(_testId))
-        {
-            httpRequest.Headers.TryAddWithoutValidation("X-Test-Id", _testId);
-        }
-
-        using var response = await _http.SendAsync(httpRequest);
-        var text = await response.Content.ReadAsStringAsync();
-        object? value = null;
-        if (!string.IsNullOrWhiteSpace(text))
-        {
-            using var doc = JsonDocument.Parse(text);
-            if (doc.RootElement.TryGetProperty("featureFlags", out var flags)
-                && flags.ValueKind == JsonValueKind.Object
-                && flags.TryGetProperty(request.Key ?? "", out var flagValue))
-            {
-                value = ToObject(flagValue);
-            }
-        }
+        var value = await FetchFeatureFlagWithRetriesAsync(body, request.Key ?? "");
 
         Capture(new CaptureRequest
         {
@@ -225,6 +206,62 @@ sealed class AdapterState : IDisposable
     }
 
     public void Dispose() => _http.Dispose();
+
+    async Task<object?> FetchFeatureFlagWithRetriesAsync(Dictionary<string, object?> body, string key)
+    {
+        for (var attempt = 0; attempt <= _maxRetries; attempt++)
+        {
+            if (attempt > 0)
+            {
+                lock (_lock) _totalRetries++;
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{_host}/flags/?v=2");
+            request.Content = JsonContent(body);
+            if (!string.IsNullOrEmpty(_testId))
+            {
+                request.Headers.TryAddWithoutValidation("X-Test-Id", _testId);
+            }
+
+            HttpResponseMessage? response = null;
+            var statusCode = 0;
+            try
+            {
+                response = await _http.SendAsync(request);
+                statusCode = (int)response.StatusCode;
+                if (statusCode >= 200 && statusCode < 300)
+                {
+                    var text = await response.Content.ReadAsStringAsync();
+                    if (!string.IsNullOrWhiteSpace(text))
+                    {
+                        using var doc = JsonDocument.Parse(text);
+                        if (doc.RootElement.TryGetProperty("featureFlags", out var flags)
+                            && flags.ValueKind == JsonValueKind.Object
+                            && flags.TryGetProperty(key, out var flagValue))
+                        {
+                            return ToObject(flagValue);
+                        }
+                    }
+                    return null;
+                }
+            }
+            catch (Exception ex)
+            {
+                lock (_lock) _lastError = ex.Message;
+            }
+            finally
+            {
+                response?.Dispose();
+            }
+
+            if (!IsRetryableFeatureFlagStatus(statusCode) || attempt >= _maxRetries)
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
 
     async Task<bool> SendWithRetriesAsync(List<Dictionary<string, object?>> batch, string path)
     {
@@ -313,6 +350,8 @@ sealed class AdapterState : IDisposable
     }
 
     static bool IsRetryable(int statusCode) => statusCode == 0 || statusCode == 408 || statusCode == 429 || statusCode >= 500;
+
+    static bool IsRetryableFeatureFlagStatus(int statusCode) => statusCode == 502 || statusCode == 504;
 
     static TimeSpan RetryDelay(HttpResponseMessage? response, int attempt)
     {

--- a/sdk_compliance_adapter/Program.cs
+++ b/sdk_compliance_adapter/Program.cs
@@ -232,6 +232,7 @@ sealed class AdapterState : IDisposable
                 if (statusCode >= 200 && statusCode < 300)
                 {
                     var text = await response.Content.ReadAsStringAsync();
+                    response.Dispose();
                     if (!string.IsNullOrWhiteSpace(text))
                     {
                         using var doc = JsonDocument.Parse(text);
@@ -249,15 +250,16 @@ sealed class AdapterState : IDisposable
             {
                 lock (_lock) _lastError = ex.Message;
             }
-            finally
-            {
-                response?.Dispose();
-            }
 
             if (!IsRetryableFeatureFlagStatus(statusCode) || attempt >= _maxRetries)
             {
+                response?.Dispose();
                 return null;
             }
+
+            var delay = RetryDelay(response, attempt);
+            response?.Dispose();
+            await Task.Delay(delay);
         }
 
         return null;
@@ -351,7 +353,7 @@ sealed class AdapterState : IDisposable
 
     static bool IsRetryable(int statusCode) => statusCode == 0 || statusCode == 408 || statusCode == 429 || statusCode >= 500;
 
-    static bool IsRetryableFeatureFlagStatus(int statusCode) => statusCode == 502 || statusCode == 504;
+    static bool IsRetryableFeatureFlagStatus(int statusCode) => statusCode == 0 || statusCode == 502 || statusCode == 504;
 
     static TimeSpan RetryDelay(HttpResponseMessage? response, int attempt)
     {


### PR DESCRIPTION
## :bulb: Motivation and Context

The SDK compliance adapter performed a direct `/flags` request for `/get_feature_flag`. When the harness configured transient 502/504 responses, the adapter did not retry and the feature flag retry compliance tests failed.

This mirrors the SDK retry behavior in the compliance adapter's feature flag request path for retryable `/flags` statuses, including network-level failures and retry backoff.

## :green_heart: How did you test it?

- `dotnet build` in `sdk_compliance_adapter`
- `/tmp/run_sdk_harness.sh "$HOME/Github/posthog-unity-chore-sdk-compliance-flag-retries" sdk_compliance_adapter/Dockerfile /tmp/sdk-harness-reports/posthog-unity-pr-comments.md '' 1 ''` — 46/46 passed

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent and subagents were used to run the SDK compliance harness across cloned SDK repositories and investigate the failing feature flag retry cases. The change is limited to the compliance adapter so the harness exercises the expected retry contract for transient `/flags` failures.
