### PR TITLE
feat: add before send callback

### DIFF
--- a/.changeset/bright-owls-filter.md
+++ b/.changeset/bright-owls-filter.md
@@ -1,0 +1,5 @@
+---
+"com.posthog.unity": minor
+---
+
+Add a beforeSend callback for modifying or dropping fully enriched events.

--- a/api/PostHog.PublicAPI.Shipped.txt
+++ b/api/PostHog.PublicAPI.Shipped.txt
@@ -103,6 +103,7 @@ namespace PostHogUnity
     {
         public PostHogConfig() { }
         public string ApiKey { get; set; }
+        public System.Func<PostHogUnity.PostHogEvent, PostHogUnity.PostHogEvent> BeforeSend { get; set; }
         public bool CaptureApplicationLifecycleEvents { get; set; }
         public bool CaptureExceptions { get; set; }
         public bool CaptureExceptionsInEditor { get; set; }

--- a/com.posthog.unity/Runtime/PostHogConfig.cs
+++ b/com.posthog.unity/Runtime/PostHogConfig.cs
@@ -107,6 +107,12 @@ namespace PostHogUnity
         public Action OnFeatureFlagsLoaded { get; set; }
 
         /// <summary>
+        /// Callback invoked after an event is fully enriched and before it is queued.
+        /// Return the event (mutated or unchanged) to continue, or null to drop it.
+        /// </summary>
+        public Func<PostHogEvent, PostHogEvent> BeforeSend { get; set; }
+
+        /// <summary>
         /// Whether to flush events before the application quits.
         /// When true, the SDK uses Application.wantsToQuit to delay quitting
         /// until the final flush completes (with a timeout).

--- a/com.posthog.unity/Runtime/PostHogConfig.cs
+++ b/com.posthog.unity/Runtime/PostHogConfig.cs
@@ -109,6 +109,7 @@ namespace PostHogUnity
         /// <summary>
         /// Callback invoked after an event is fully enriched and before it is queued.
         /// Return the event (mutated or unchanged) to continue, or null to drop it.
+        /// If the callback throws, the SDK logs the exception and drops the event.
         /// </summary>
         public Func<PostHogEvent, PostHogEvent> BeforeSend { get; set; }
 

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -414,14 +414,40 @@ namespace PostHogUnity
                 eventProps["$groups"] = groups;
             }
 
-            // Create and enqueue the event
+            // Create the fully enriched event, then give customers a final chance to modify or drop it.
             var evt = new PostHogEvent(eventName, _identityManager.DistinctId, eventProps);
+            evt = RunBeforeSend(evt);
+            if (evt == null)
+            {
+                PostHogLogger.Debug($"Event dropped by beforeSend: {eventName}");
+                return;
+            }
+
             _eventQueue.Enqueue(evt);
 
             // Touch session
             _sessionManager.Touch();
 
             PostHogLogger.Debug($"Captured event: {eventName}");
+        }
+
+        PostHogEvent RunBeforeSend(PostHogEvent evt)
+        {
+            var beforeSend = _config.BeforeSend;
+            if (beforeSend == null)
+            {
+                return evt;
+            }
+
+            try
+            {
+                return beforeSend(evt);
+            }
+            catch (Exception ex)
+            {
+                PostHogLogger.Error("beforeSend callback threw", ex);
+                return null;
+            }
         }
 
         void AddSdkProperties(Dictionary<string, object> properties)

--- a/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
@@ -138,6 +138,91 @@ namespace PostHogUnity.Tests
             }
         }
 
+        public class TheBeforeSendCallback
+        {
+            [Fact]
+            public void CanModifyFullyEnrichedEventBeforeItIsQueued()
+            {
+                var sawFullyEnrichedEvent = false;
+                var config = new PostHogConfig
+                {
+                    ApiKey = "test-api-key",
+                    BeforeSend = evt =>
+                    {
+                        sawFullyEnrichedEvent = evt.Properties.ContainsKey("$lib")
+                            && evt.Properties.ContainsKey("$lib_version")
+                            && evt.Properties.ContainsKey("$session_id")
+                            && evt.Properties.ContainsKey("source");
+                        evt.Properties.Remove("secret");
+                        evt.Properties["before_send"] = true;
+                        return evt;
+                    },
+                };
+                var sdk = CreateSdk(config);
+                var evt = new PostHogEvent(
+                    "before-send-event",
+                    "distinct-id",
+                    new Dictionary<string, object>
+                    {
+                        ["$lib"] = "posthog-unity",
+                        ["$lib_version"] = "1.0.0",
+                        ["$session_id"] = "session-id",
+                        ["source"] = "super",
+                        ["secret"] = "remove",
+                    }
+                );
+
+                var processed = RunBeforeSend(sdk, evt);
+
+                Assert.True(sawFullyEnrichedEvent);
+                Assert.NotNull(processed);
+                Assert.True((bool)processed.Properties["before_send"]);
+                Assert.False(processed.Properties.ContainsKey("secret"));
+            }
+
+            [Fact]
+            public void CanDropEventBeforeItIsQueued()
+            {
+                var config = new PostHogConfig
+                {
+                    ApiKey = "test-api-key",
+                    BeforeSend = _ => null,
+                };
+                var sdk = CreateSdk(config);
+
+                var processed = RunBeforeSend(sdk, new PostHogEvent("drop-me", "distinct-id"));
+
+                Assert.Null(processed);
+            }
+
+            static PostHogSDK CreateSdk(PostHogConfig config)
+            {
+                var sdk = (PostHogSDK)RuntimeHelpers.GetUninitializedObject(typeof(PostHogSDK));
+                SetField(sdk, "_config", config);
+                return sdk;
+            }
+
+            static PostHogEvent RunBeforeSend(PostHogSDK sdk, PostHogEvent evt)
+            {
+                var method = typeof(PostHogSDK).GetMethod(
+                    "RunBeforeSend",
+                    BindingFlags.Instance | BindingFlags.NonPublic
+                );
+                Assert.NotNull(method);
+                return (PostHogEvent)method.Invoke(sdk, new object[] { evt });
+            }
+
+            static void SetField(PostHogSDK sdk, string name, object value)
+            {
+                var field = typeof(PostHogSDK).GetField(
+                    name,
+                    BindingFlags.Instance | BindingFlags.NonPublic
+                );
+                Assert.NotNull(field);
+                field.SetValue(sdk, value);
+            }
+        }
+
         [Collection("UnityGlobals")]
         public class ThePublicApiMethods
         {

--- a/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
@@ -141,18 +141,13 @@ namespace PostHogUnity.Tests
         public class TheBeforeSendCallback
         {
             [Fact]
-            public void CanModifyFullyEnrichedEventBeforeItIsQueued()
+            public void CanModifyEventBeforeItIsQueued()
             {
-                var sawFullyEnrichedEvent = false;
                 var config = new PostHogConfig
                 {
                     ApiKey = "test-api-key",
                     BeforeSend = evt =>
                     {
-                        sawFullyEnrichedEvent = evt.Properties.ContainsKey("$lib")
-                            && evt.Properties.ContainsKey("$lib_version")
-                            && evt.Properties.ContainsKey("$session_id")
-                            && evt.Properties.ContainsKey("source");
                         evt.Properties.Remove("secret");
                         evt.Properties["before_send"] = true;
                         return evt;
@@ -174,25 +169,32 @@ namespace PostHogUnity.Tests
 
                 var processed = RunBeforeSend(sdk, evt);
 
-                Assert.True(sawFullyEnrichedEvent);
                 Assert.NotNull(processed);
                 Assert.True((bool)processed.Properties["before_send"]);
                 Assert.False(processed.Properties.ContainsKey("secret"));
             }
 
-            [Fact]
-            public void CanDropEventBeforeItIsQueued()
+            [Theory]
+            [MemberData(nameof(DropCallbacks))]
+            public void CanDropEventBeforeItIsQueued(Func<PostHogEvent, PostHogEvent> beforeSend)
             {
-                var config = new PostHogConfig
-                {
-                    ApiKey = "test-api-key",
-                    BeforeSend = _ => null,
-                };
+                var config = new PostHogConfig { ApiKey = "test-api-key", BeforeSend = beforeSend };
                 var sdk = CreateSdk(config);
 
                 var processed = RunBeforeSend(sdk, new PostHogEvent("drop-me", "distinct-id"));
 
                 Assert.Null(processed);
+            }
+
+            public static IEnumerable<object[]> DropCallbacks()
+            {
+                yield return new object[] { (Func<PostHogEvent, PostHogEvent>)(_ => null) };
+                yield return new object[]
+                {
+                    (Func<PostHogEvent, PostHogEvent>)(
+                        _ => throw new InvalidOperationException("beforeSend failed")
+                    ),
+                };
             }
 
             static PostHogSDK CreateSdk(PostHogConfig config)


### PR DESCRIPTION
## :bulb: Motivation and Context

Customers need a configuration hook to inspect, modify, or drop events before upload, matching the before-send behavior available in other PostHog SDKs.

This adds `PostHogConfig.BeforeSend`. It receives a fully enriched `PostHogEvent` after SDK, session, super property, and group enrichment. Returning `null` drops the event before it is queued.

## :green_heart: How did you test it?

- `bin/check-public-api`
- `dotnet test tests/PostHog.Unity.Tests/PostHog.Unity.Tests.csproj --filter 'FullyQualifiedName~TheBeforeSendCallback'`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the pi coding agent. The callback runs after event construction/enrichment and before queueing, so customers can mutate the outgoing event or return `null` to drop it.
