### PR TITLE
Fix placeholder .meta GUIDs in ErrorTracking that collide with other packages

### DIFF
--- a/com.posthog.unity/Runtime/ErrorTracking/ExceptionManager.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/ExceptionManager.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0
+guid: 71186b19f6175a8afb839cef4d1fd871
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7
+guid: c7bb19aa23906599690482106ef5ef8b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8
+guid: a0b5f838ba50c8363264893e7dfc1e92
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+guid: f84ca2fb3b14e37f5f9a7921c3480bd1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.posthog.unity/Runtime/ErrorTracking/WebGLExceptionIntegration.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/WebGLExceptionIntegration.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9
+guid: a278dcd2d53504185e62c7e55016c5e2
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
## Problem

The five `com.posthog.unity/Runtime/ErrorTracking/*.cs.meta` files ship hand-typed **sequential placeholder GUIDs**:

| File | GUID |
|------|------|
| `UnityStackTraceParser.cs.meta` | `a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6` |
| `ExceptionPropertiesBuilder.cs.meta` | `b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7` |
| `UnityExceptionIntegration.cs.meta` | `c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8` |
| `WebGLExceptionIntegration.cs.meta` | `d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9` |
| `ExceptionManager.cs.meta` | `e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0` |

These are present in every release (v1.0.0–v1.1.0). Because they are not real random GUIDs, they can collide with other packages/assets in the same project that also used placeholder GUIDs. When that happens Unity treats them as duplicates, **silently ignores the PostHog files** (the other package is the "current owner", and the PostHog files sit in an immutable package folder so no new GUID can be assigned), and `PostHogSDK.cs` then fails to compile:

```
error CS0234: The type or namespace name 'ErrorTracking' does not exist in the namespace 'PostHogUnity'
error CS0246: The type or namespace name 'ExceptionManager' could not be found
```

We hit this in a real Unity 6 project where another package happened to use the same placeholder GUIDs, and it took down the entire compile.

## Fix

Replace the five placeholder GUIDs with fresh unique ones. No `.cs`/asmdef/asset references these GUIDs (verified by searching the whole package), so this is a metadata-only change with no code impact.

## Test

Imported the patched package into a Unity 6 (6000.0.60f1) project alongside the package that previously collided — the `ErrorTracking` types now resolve and the SDK compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)