### PR TITLE
fix: replace placeholder ErrorTracking GUIDs

### DIFF
--- a/.changeset/fresh-guids-track.md
+++ b/.changeset/fresh-guids-track.md
@@ -1,0 +1,5 @@
+---
+'com.posthog.unity': patch
+---
+
+Replace placeholder ErrorTracking asset GUIDs to prevent collisions with other Unity packages.

--- a/com.posthog.unity/Runtime/ErrorTracking.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8c3e9f0a2b4d5e6f7a1b2c3d4e5f6a7b
+guid: 075a5930deb15dd2d1a2ebcf5c57cb04
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/com.posthog.unity/Runtime/ErrorTracking/ExceptionManager.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/ExceptionManager.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0
+guid: cee95eeeff2c20b8ee9dcb1bff6e6dfb
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7
+guid: 604f31b1858de5ed8da2fb4456fa5c5e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityExceptionIntegration.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8
+guid: ccd7f46e38ab7caa9f58962048d7965f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/UnityStackTraceParser.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+guid: 80d68000421dbbeee8787966f654d71d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.posthog.unity/Runtime/ErrorTracking/WebGLExceptionIntegration.cs.meta
+++ b/com.posthog.unity/Runtime/ErrorTracking/WebGLExceptionIntegration.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9
+guid: 0bb8ebe5bc5dcc8bb684efacd71ffe7a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
## :bulb: Motivation and Context

The ErrorTracking folder and its five C# scripts use hand-written sequential placeholder GUIDs. Unity requires asset GUIDs to be unique across the entire project; when an immutable package asset collides with another asset, Unity ignores one owner, which can remove ErrorTracking sources from compilation.

This supersedes #116 and includes the placeholder GUID on `Runtime/ErrorTracking.meta` that the original PR did not change. Thanks to @altair-martinez for reporting the problem and proposing the initial fix.

## :green_heart: How did you test it?

- `./bin/build`
- `./bin/check-public-api`
- `./bin/fmt --check`
- `./bin/test` — 451 passed, 2 skipped
- Scanned all 58 package `.meta` files: every GUID is valid and unique, all six replacements are present, and none of the old placeholders remain.
- Reproduced end-to-end with Unity 6000.5.5f1 in batch mode:
  - Imported an `Assets/CollisionOwner.cs` asset with the old `ExceptionManager.cs` GUID, then installed `main` commit `12d5a48` as an immutable Git UPM dependency. Unity ignored the package script and exited with `CS0246` because `ExceptionManager` was missing.
  - Switched the same project to this PR's commit while preserving the collision owner. Unity exited successfully and built `PostHog.dll` with no GUID conflict or compiler errors.
  - Repeated the test with an asset folder owning the old `Runtime/ErrorTracking.meta` GUID. `main` reported that the immutable package folder was ignored; this PR imported the folder under its new GUID and compiled successfully.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A maintainer directed Pi coding agent (GPT-5.6) to investigate #116 and prepare a replacement PR using shell, Git, GitHub CLI, and Unity 6000.5.5f1 batch-mode tooling. The replacement changes all six placeholder GUIDs rather than only the five script GUIDs and was validated against controlled script and folder GUID collisions in immutable Git packages.
