### PR TITLE
ci: update SDK compliance harness

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@eea2a62aa490b1bfa2e2b3488fc0042b89cfa5ed
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - test-network
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.9.0
+    image: ghcr.io/posthog/sdk-test-harness:0.10.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "server", "--debug"]
     networks:
       - test-network


### PR DESCRIPTION
## :bulb: Motivation and Context

The SDK compliance workflow is pinned to an older reusable workflow whose actions target Node.js 20, producing deprecation warnings on GitHub Actions. The CI and local Docker Compose compliance harness images are also one release behind and do not include the latest `/flags` retry contract coverage.

This updates the reusable workflow and aligns both CI and local compliance harness pins while keeping the compliance setup otherwise unchanged.

## :green_heart: How did you test it?

- Parsed `.github/workflows/sdk-compliance.yml` successfully as YAML.
- Ran `docker compose -f sdk_compliance_adapter/docker-compose.yml config --quiet`.
- Ran `git diff --check`.
- Verified the pinned reusable workflow uses the Node.js 24-compatible action versions.
- Verified the `ghcr.io/posthog/sdk-test-harness:0.10.0` image manifest exists.
- CI SDK compliance tests passed 46/46 on the initial commit.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A maintainer directed Pi coding agent (GPT-5.6) to audit PR #120's CI logs and update the stale SDK compliance pins. The agent used shell, Git, GitHub CLI, and Docker tooling; after review feedback, the local Docker Compose harness pin was aligned with CI.
