### PR TITLE
test: snapshot event and request shapes

### DIFF
--- a/com.posthog.unity/Runtime/Core/NetworkClient.cs
+++ b/com.posthog.unity/Runtime/Core/NetworkClient.cs
@@ -65,17 +65,9 @@ namespace PostHogUnity
         /// <param name="onComplete">Callback with (success, statusCode)</param>
         public IEnumerator SendBatch(BatchPayload payload, Action<bool, int> onComplete)
         {
-            var url = GetBatchUrl();
-            var json = JsonSerializer.SerializeBatch(payload);
+            using var request = CreateBatchRequest(payload);
 
-            PostHogLogger.Debug($"Sending batch to {url}");
-
-            using var request = new UnityWebRequest(url, "POST");
-            var bodyRaw = Encoding.UTF8.GetBytes(json);
-            request.uploadHandler = new UploadHandlerRaw(bodyRaw);
-            request.downloadHandler = new DownloadHandlerBuffer();
-            ApplyDefaultHeaders(request);
-            request.timeout = TimeoutSeconds;
+            PostHogLogger.Debug($"Sending batch to {request.url}");
 
             yield return request.SendWebRequest();
 
@@ -160,6 +152,19 @@ namespace PostHogUnity
 
                 yield return _featureFlagsRetryDelayFactory(attempt);
             }
+        }
+
+        internal UnityWebRequest CreateBatchRequest(BatchPayload payload)
+        {
+            return CreateWebRequest(CreateBatchRequestData(payload));
+        }
+
+        internal HttpRequestData CreateBatchRequestData(BatchPayload payload)
+        {
+            return CreateJsonRequestData(
+                GetBatchUrl(),
+                Encoding.UTF8.GetBytes(JsonSerializer.SerializeBatch(payload))
+            );
         }
 
         string GetBatchUrl()
@@ -284,6 +289,29 @@ namespace PostHogUnity
             Dictionary<string, Dictionary<string, object>> groupProperties = null
         )
         {
+            return CreateWebRequest(
+                CreateFlagsRequestData(
+                    apiKey,
+                    host,
+                    distinctId,
+                    anonymousId,
+                    groups,
+                    personProperties,
+                    groupProperties
+                )
+            );
+        }
+
+        internal static HttpRequestData CreateFlagsRequestData(
+            string apiKey,
+            string host,
+            string distinctId,
+            string anonymousId = null,
+            Dictionary<string, string> groups = null,
+            IReadOnlyDictionary<string, object> personProperties = null,
+            Dictionary<string, Dictionary<string, object>> groupProperties = null
+        )
+        {
             var normalizedHost = host.TrimEnd('/');
             var url = $"{normalizedHost}/flags/?v={FeatureFlagsResponse.CurrentVersion}";
 
@@ -313,23 +341,49 @@ namespace PostHogUnity
                 body["group_properties"] = groupProperties;
             }
 
-            var json = JsonSerializer.Serialize(body);
+            return CreateJsonRequestData(
+                url,
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(body))
+            );
+        }
 
-            var request = new UnityWebRequest(url, "POST");
-            var bodyRaw = Encoding.UTF8.GetBytes(json);
-            request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+        internal static HttpRequestData CreateJsonRequestData(string url, byte[] body)
+        {
+            return new HttpRequestData
+            {
+                Url = url,
+                Method = "POST",
+                Body = body,
+                TimeoutSeconds = TimeoutSeconds,
+                Headers = new Dictionary<string, string>
+                {
+                    ["Content-Type"] = "application/json",
+                    ["Accept"] = "application/json",
+                    ["User-Agent"] = SdkInfo.UserAgent,
+                },
+            };
+        }
+
+        internal static UnityWebRequest CreateWebRequest(HttpRequestData data)
+        {
+            var request = new UnityWebRequest(data.Url, data.Method);
+            request.uploadHandler = new UploadHandlerRaw(data.Body);
             request.downloadHandler = new DownloadHandlerBuffer();
-            ApplyDefaultHeaders(request);
-            request.timeout = TimeoutSeconds;
-
+            foreach (var header in data.Headers)
+            {
+                request.SetRequestHeader(header.Key, header.Value);
+            }
+            request.timeout = data.TimeoutSeconds;
             return request;
         }
+    }
 
-        static void ApplyDefaultHeaders(UnityWebRequest request)
-        {
-            request.SetRequestHeader("Content-Type", "application/json");
-            request.SetRequestHeader("Accept", "application/json");
-            request.SetRequestHeader("User-Agent", SdkInfo.UserAgent);
-        }
+    class HttpRequestData
+    {
+        public string Url { get; set; }
+        public string Method { get; set; }
+        public byte[] Body { get; set; }
+        public Dictionary<string, string> Headers { get; set; }
+        public int TimeoutSeconds { get; set; }
     }
 }

--- a/com.posthog.unity/Runtime/ErrorTracking/ExceptionManager.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/ExceptionManager.cs
@@ -17,6 +17,7 @@ namespace PostHogUnity.ErrorTracking
         readonly PostHogConfig _config;
         readonly Action<string, Dictionary<string, object>> _captureEvent;
         readonly Func<string> _getDistinctId;
+        readonly Func<ExceptionRuntimeInfo> _getRuntimeInfo;
 
         UnityExceptionIntegration _exceptionIntegration;
         WebGLExceptionIntegration _webglIntegration;
@@ -27,12 +28,14 @@ namespace PostHogUnity.ErrorTracking
         public ExceptionManager(
             PostHogConfig config,
             Action<string, Dictionary<string, object>> captureEvent,
-            Func<string> getDistinctId
+            Func<string> getDistinctId,
+            Func<ExceptionRuntimeInfo> getRuntimeInfo = null
         )
         {
             _config = config;
             _captureEvent = captureEvent;
             _getDistinctId = getDistinctId;
+            _getRuntimeInfo = getRuntimeInfo ?? ExceptionRuntimeInfo.Capture;
         }
 
         /// <summary>
@@ -147,7 +150,7 @@ namespace PostHogUnity.ErrorTracking
                         $"{host}/project/{_config.ApiKey}/person/{distinctId}";
                 }
 
-                ExceptionPropertiesBuilder.Build(properties, exception, handled);
+                ExceptionPropertiesBuilder.Build(properties, exception, handled, _getRuntimeInfo());
 
                 _captureEvent?.Invoke("$exception", properties);
                 _lastExceptionTime = DateTime.UtcNow;

--- a/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs
+++ b/com.posthog.unity/Runtime/ErrorTracking/ExceptionPropertiesBuilder.cs
@@ -23,9 +23,11 @@ namespace PostHogUnity.ErrorTracking
         public static Dictionary<string, object> Build(
             Dictionary<string, object> properties,
             Exception exception,
-            bool handled = false
+            bool handled = false,
+            ExceptionRuntimeInfo? runtimeInfo = null
         )
         {
+            var resolvedRuntimeInfo = runtimeInfo ?? ExceptionRuntimeInfo.Capture();
             properties["$exception_type"] =
                 exception.GetType().FullName ?? exception.GetType().Name;
             properties["$exception_message"] = exception.Message;
@@ -34,10 +36,10 @@ namespace PostHogUnity.ErrorTracking
             properties["$exception_handled"] = handled;
             properties["$lib"] = SdkInfo.LibraryName;
             properties["$lib_version"] = SdkInfo.Version;
-            properties["$os"] = GetOperatingSystem();
-            properties["$os_version"] = SystemInfo.operatingSystem;
-            properties["$device_model"] = SystemInfo.deviceModel;
-            properties["$unity_version"] = Application.unityVersion;
+            properties["$os"] = resolvedRuntimeInfo.OperatingSystem;
+            properties["$os_version"] = resolvedRuntimeInfo.OperatingSystemVersion;
+            properties["$device_model"] = resolvedRuntimeInfo.DeviceModel;
+            properties["$unity_version"] = resolvedRuntimeInfo.UnityVersion;
 
             properties["$exception_list"] = BuildExceptionList(exception, handled);
 
@@ -225,7 +227,7 @@ namespace PostHogUnity.ErrorTracking
             return message;
         }
 
-        static string GetOperatingSystem()
+        internal static string GetOperatingSystem()
         {
 #if UNITY_IOS
             return "iOS";
@@ -242,6 +244,37 @@ namespace PostHogUnity.ErrorTracking
 #else
             return Application.platform.ToString();
 #endif
+        }
+    }
+
+    readonly struct ExceptionRuntimeInfo
+    {
+        public string OperatingSystem { get; }
+        public string OperatingSystemVersion { get; }
+        public string DeviceModel { get; }
+        public string UnityVersion { get; }
+
+        public ExceptionRuntimeInfo(
+            string operatingSystem,
+            string operatingSystemVersion,
+            string deviceModel,
+            string unityVersion
+        )
+        {
+            OperatingSystem = operatingSystem;
+            OperatingSystemVersion = operatingSystemVersion;
+            DeviceModel = deviceModel;
+            UnityVersion = unityVersion;
+        }
+
+        public static ExceptionRuntimeInfo Capture()
+        {
+            return new ExceptionRuntimeInfo(
+                ExceptionPropertiesBuilder.GetOperatingSystem(),
+                SystemInfo.operatingSystem,
+                SystemInfo.deviceModel,
+                Application.unityVersion
+            );
         }
     }
 }

--- a/com.posthog.unity/Runtime/PostHogSDK.cs
+++ b/com.posthog.unity/Runtime/PostHogSDK.cs
@@ -34,6 +34,7 @@ namespace PostHogUnity
         ExceptionManager _exceptionManager;
         SessionReplayIntegration _sessionReplayIntegration;
         Dictionary<string, object> _superProperties;
+        Func<SdkRuntimeInfo> _getSdkRuntimeInfo;
         bool _optedOut;
 
         /// <summary>
@@ -145,6 +146,7 @@ namespace PostHogUnity
         {
             _config = config;
             _superProperties = new Dictionary<string, object>();
+            _getSdkRuntimeInfo = SdkRuntimeInfo.Capture;
 
             PostHogLogger.SetLogLevel(config.LogLevel);
 
@@ -452,20 +454,21 @@ namespace PostHogUnity
 
         void AddSdkProperties(Dictionary<string, object> properties)
         {
+            var runtimeInfo = (_getSdkRuntimeInfo ?? SdkRuntimeInfo.Capture)();
             properties["$lib"] = SdkInfo.LibraryName;
             properties["$lib_version"] = SdkInfo.Version;
 
             // Add device/platform properties
-            properties["$os"] = PlatformInfo.GetOperatingSystem();
-            properties["$os_version"] = SystemInfo.operatingSystem;
-            properties["$device_type"] = PlatformInfo.GetDeviceType();
-            properties["$device_manufacturer"] = SystemInfo.deviceModel;
-            properties["$device_model"] = SystemInfo.deviceModel;
-            properties["$screen_width"] = UnityEngine.Screen.width;
-            properties["$screen_height"] = UnityEngine.Screen.height;
-            properties["$app_version"] = Application.version;
-            properties["$app_build"] = Application.buildGUID;
-            properties["$app_name"] = Application.productName;
+            properties["$os"] = runtimeInfo.OperatingSystem;
+            properties["$os_version"] = runtimeInfo.OperatingSystemVersion;
+            properties["$device_type"] = runtimeInfo.DeviceType;
+            properties["$device_manufacturer"] = runtimeInfo.DeviceModel;
+            properties["$device_model"] = runtimeInfo.DeviceModel;
+            properties["$screen_width"] = runtimeInfo.ScreenWidth;
+            properties["$screen_height"] = runtimeInfo.ScreenHeight;
+            properties["$app_version"] = runtimeInfo.AppVersion;
+            properties["$app_build"] = runtimeInfo.AppBuild;
+            properties["$app_name"] = runtimeInfo.AppName;
 
             // Person profiles mode
             if (
@@ -1165,5 +1168,56 @@ namespace PostHogUnity
         }
 
         #endregion
+    }
+
+    readonly struct SdkRuntimeInfo
+    {
+        public string OperatingSystem { get; }
+        public string OperatingSystemVersion { get; }
+        public string DeviceType { get; }
+        public string DeviceModel { get; }
+        public int ScreenWidth { get; }
+        public int ScreenHeight { get; }
+        public string AppVersion { get; }
+        public string AppBuild { get; }
+        public string AppName { get; }
+
+        public SdkRuntimeInfo(
+            string operatingSystem,
+            string operatingSystemVersion,
+            string deviceType,
+            string deviceModel,
+            int screenWidth,
+            int screenHeight,
+            string appVersion,
+            string appBuild,
+            string appName
+        )
+        {
+            OperatingSystem = operatingSystem;
+            OperatingSystemVersion = operatingSystemVersion;
+            DeviceType = deviceType;
+            DeviceModel = deviceModel;
+            ScreenWidth = screenWidth;
+            ScreenHeight = screenHeight;
+            AppVersion = appVersion;
+            AppBuild = appBuild;
+            AppName = appName;
+        }
+
+        public static SdkRuntimeInfo Capture()
+        {
+            return new SdkRuntimeInfo(
+                PlatformInfo.GetOperatingSystem(),
+                SystemInfo.operatingSystem,
+                PlatformInfo.GetDeviceType(),
+                SystemInfo.deviceModel,
+                UnityEngine.Screen.width,
+                UnityEngine.Screen.height,
+                Application.version,
+                Application.buildGUID,
+                Application.productName
+            );
+        }
     }
 }

--- a/com.posthog.unity/Runtime/SessionReplay/ReplayQueue.cs
+++ b/com.posthog.unity/Runtime/SessionReplay/ReplayQueue.cs
@@ -306,35 +306,12 @@ namespace PostHogUnity.SessionReplay
 
         IEnumerator SendBatch(List<SnapshotEvent> events, Action<bool, int> onComplete)
         {
-            var url = $"{_host}/s/";
-
-            var batchList = new List<Dictionary<string, object>>();
-            foreach (var evt in events)
-            {
-                batchList.Add(evt.ToDictionary(_apiKey));
-            }
-
-            var json = JsonSerializer.Serialize(batchList);
-            var bodyBytes = Encoding.UTF8.GetBytes(json);
-
-            var (payloadBytes, useCompression) = PreparePayload(bodyBytes, CompressGzip);
+            var requestData = CreateBatchRequestData(events);
             PostHogLogger.Debug(
-                $"Sending replay batch to {url} (size: {payloadBytes.Length} bytes)"
+                $"Sending replay batch to {requestData.Url} (size: {requestData.Body.Length} bytes)"
             );
 
-            using var request = new UnityWebRequest(url, "POST");
-            request.uploadHandler = new UploadHandlerRaw(payloadBytes);
-            request.downloadHandler = new DownloadHandlerBuffer();
-            request.SetRequestHeader("Content-Type", "application/json");
-            request.SetRequestHeader("Accept", "application/json");
-
-            if (useCompression)
-            {
-                request.SetRequestHeader("Content-Encoding", "gzip");
-            }
-
-            request.timeout = TimeoutSeconds;
-
+            using var request = NetworkClient.CreateWebRequest(requestData);
             yield return request.SendWebRequest();
 
             int statusCode = (int)request.responseCode;
@@ -351,6 +328,38 @@ namespace PostHogUnity.SessionReplay
                 );
                 onComplete?.Invoke(false, statusCode);
             }
+        }
+
+        internal HttpRequestData CreateBatchRequestData(List<SnapshotEvent> events)
+        {
+            var batchList = new List<Dictionary<string, object>>();
+            foreach (var evt in events)
+            {
+                batchList.Add(evt.ToDictionary(_apiKey));
+            }
+
+            var json = JsonSerializer.Serialize(batchList);
+            var bodyBytes = Encoding.UTF8.GetBytes(json);
+            var (payloadBytes, useCompression) = PreparePayload(bodyBytes, CompressGzip);
+            var headers = new Dictionary<string, string>
+            {
+                ["Content-Type"] = "application/json",
+                ["Accept"] = "application/json",
+            };
+
+            if (useCompression)
+            {
+                headers["Content-Encoding"] = "gzip";
+            }
+
+            return new HttpRequestData
+            {
+                Url = $"{_host}/s/",
+                Method = "POST",
+                Body = payloadBytes,
+                Headers = headers,
+                TimeoutSeconds = TimeoutSeconds,
+            };
         }
 
         internal static (byte[] PayloadBytes, bool UseCompression) PreparePayload(

--- a/tests/PostHog.Unity.Tests/EventShapeSnapshotTests.cs
+++ b/tests/PostHog.Unity.Tests/EventShapeSnapshotTests.cs
@@ -1,0 +1,346 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Nodes;
+using PostHogUnity.ErrorTracking;
+
+namespace PostHogUnity.Tests
+{
+    public class EventShapeSnapshotTests
+    {
+        [Fact]
+        public async Task CapturedEventsMatchGoldenShapes()
+        {
+            var harness = new SdkPipelineHarness();
+
+            harness.Capture(
+                "checkout completed",
+                new Dictionary<string, object>
+                {
+                    ["amount"] = 42.5,
+                    ["currency"] = "USD",
+                    ["items"] = new List<object> { "hedgehog plush", "sticker" },
+                    ["plan"] = "enterprise",
+                }
+            );
+            await harness.Identify(
+                "user-123",
+                new Dictionary<string, object>
+                {
+                    ["email"] = "person@example.com",
+                    ["name"] = "Hedge Hog",
+                },
+                new Dictionary<string, object> { ["created_via"] = "unity" }
+            );
+            harness.Group(
+                "company",
+                "posthog",
+                new Dictionary<string, object> { ["name"] = "PostHog", ["employees"] = 100 }
+            );
+            harness.TrackFeatureFlag();
+            harness.CaptureException(
+                CreateSnapshotException(),
+                new Dictionary<string, object> { ["scene"] = "Checkout" }
+            );
+
+            var snapshots = new JsonArray();
+            foreach (var json in harness.StoredEvents)
+            {
+                var evt = JsonNode.Parse(json).AsObject();
+                NormalizeEnrichedEvent(evt);
+                snapshots.Add(evt);
+            }
+
+            GoldenSnapshot.Match("event-shapes.snap.json", snapshots);
+        }
+
+        internal static void NormalizeEnrichedEvent(JsonObject evt)
+        {
+            AssertUuidV7AndReplace(evt, "uuid");
+            AssertTimestampAndReplace(evt, "timestamp");
+
+            var properties = Assert.IsType<JsonObject>(evt["properties"]);
+            AssertUuidV7AndReplace(properties, "$session_id", "<session-id>");
+            NormalizeSdkVersion(properties);
+
+            if (properties.ContainsKey("$unity_version"))
+            {
+                Assert.Equal("2021.snapshot", properties["$unity_version"]?.GetValue<string>());
+                var exceptions = Assert.IsType<JsonArray>(properties["$exception_list"]);
+                Assert.NotEmpty(exceptions);
+                foreach (var exception in exceptions)
+                {
+                    var stacktrace = Assert.IsType<JsonObject>(exception["stacktrace"]);
+                    var frames = Assert.IsType<JsonArray>(stacktrace["frames"]);
+                    Assert.NotEmpty(frames);
+                    foreach (var frameNode in frames)
+                    {
+                        var frame = Assert.IsType<JsonObject>(frameNode);
+                        Assert.True(frame.ContainsKey("abs_path"));
+                        Assert.True(frame.ContainsKey("lineno"));
+                        Assert.True(frame.ContainsKey("colno"));
+                        Assert.True(frame["abs_path"] is JsonValue or null);
+                        Assert.True(frame["lineno"] is JsonValue or null);
+                        Assert.True(frame["colno"] is JsonValue or null);
+                        frame["abs_path"] = "<abs_path>";
+                        frame["lineno"] = "<lineno>";
+                        frame["colno"] = "<colno>";
+                    }
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Exception CreateSnapshotException()
+        {
+            try
+            {
+                throw new InvalidOperationException("snapshot boom");
+            }
+            catch (Exception exception)
+            {
+                return exception;
+            }
+        }
+
+        internal static void AssertUuidV7AndReplace(
+            JsonObject obj,
+            string propertyName,
+            string replacement = "<uuid-v7>"
+        )
+        {
+            var value = Assert.IsAssignableFrom<JsonValue>(obj[propertyName]).GetValue<string>();
+            Assert.True(Guid.TryParse(value, out _), $"{propertyName} must be a UUID");
+            Assert.Equal('7', value.Split('-')[2][0]);
+            obj[propertyName] = replacement;
+        }
+
+        internal static void AssertTimestampAndReplace(JsonObject obj, string propertyName)
+        {
+            var value = Assert.IsAssignableFrom<JsonValue>(obj[propertyName]).GetValue<string>();
+            Assert.True(
+                DateTimeOffset.TryParse(value, out _),
+                $"{propertyName} must be an ISO timestamp"
+            );
+            obj[propertyName] = "<timestamp>";
+        }
+
+        internal static void NormalizeSdkVersion(JsonObject properties)
+        {
+            var version = Assert
+                .IsAssignableFrom<JsonValue>(properties["$lib_version"])
+                .GetValue<string>();
+            Assert.False(string.IsNullOrEmpty(version));
+            properties["$lib_version"] = "<sdk-version>";
+        }
+    }
+
+    sealed class SdkPipelineHarness
+    {
+        readonly InMemoryStorageProvider _storage;
+        readonly PostHogSDK _sdk;
+        readonly FeatureFlagManager _featureFlagManager;
+        readonly ExceptionManager _exceptionManager;
+
+        public SdkPipelineHarness()
+        {
+            var config = new PostHogConfig
+            {
+                ApiKey = "phc_snapshot_key",
+                Host = "https://example.com/ingest/",
+                FlushAt = 100,
+                PreloadFeatureFlags = false,
+                PersonProfiles = PersonProfiles.IdentifiedOnly,
+            };
+            _storage = new InMemoryStorageProvider();
+            _storage.SaveState(
+                "identity",
+                "{\"_version\":1,\"anonymousId\":\"anonymous-id\",\"distinctId\":null,\"isIdentified\":false,\"groups\":{}}"
+            );
+            _storage.SaveState(
+                "feature_flags",
+                "{\"_version\":2,\"errorsWhileComputingFlags\":false,\"flags\":{\"checkout-layout\":{\"variant\":\"test\",\"metadata\":{\"id\":17,\"version\":3},\"reason\":{\"description\":\"Matched snapshot cohort\"}}},\"requestId\":\"request-123\",\"evaluatedAt\":1700000000}"
+            );
+
+            var networkClient = new NetworkClient(config);
+            var identityManager = new IdentityManager(config, _storage);
+            var sessionManager = new SessionManager(() => new DateTime(2025, 1, 2, 3, 4, 5));
+            var eventQueue = new EventQueue(config, _storage, networkClient);
+
+            _sdk = (PostHogSDK)RuntimeHelpers.GetUninitializedObject(typeof(PostHogSDK));
+            SetField(_sdk, "_config", config);
+            SetField(_sdk, "_storage", _storage);
+            SetField(_sdk, "_networkClient", networkClient);
+            SetField(_sdk, "_identityManager", identityManager);
+            SetField(_sdk, "_sessionManager", sessionManager);
+            SetField(_sdk, "_eventQueue", eventQueue);
+            SetField(
+                _sdk,
+                "_superProperties",
+                new Dictionary<string, object>
+                {
+                    ["plan"] = "starter",
+                    ["source"] = "snapshot-test",
+                }
+            );
+            SetField(
+                _sdk,
+                "_getSdkRuntimeInfo",
+                () =>
+                    new SdkRuntimeInfo(
+                        "SnapshotOS",
+                        "1.0",
+                        "Desktop",
+                        "Snapshot Device",
+                        1280,
+                        720,
+                        "1.2.3",
+                        "snapshot-build",
+                        "Snapshot Game"
+                    )
+            );
+
+            Action<string, Dictionary<string, object>> capture = Capture;
+            _featureFlagManager = new FeatureFlagManager(
+                config,
+                _storage,
+                networkClient,
+                () => identityManager.DistinctId,
+                () => identityManager.AnonymousId,
+                () => identityManager.Groups,
+                capture
+            );
+            _featureFlagManager.LoadFromCache();
+            SetField(_sdk, "_featureFlagManager", _featureFlagManager);
+
+            _exceptionManager = new ExceptionManager(
+                config,
+                capture,
+                () => identityManager.DistinctId,
+                () =>
+                    new ExceptionRuntimeInfo(
+                        "SnapshotOS",
+                        "1.0",
+                        "Snapshot Device",
+                        "2021.snapshot"
+                    )
+            );
+            SetField(_sdk, "_exceptionManager", _exceptionManager);
+        }
+
+        public IReadOnlyList<string> StoredEvents =>
+            _storage.GetEventIds().Select(_storage.LoadEvent).ToList();
+
+        public void Capture(string eventName, Dictionary<string, object> properties)
+        {
+            Invoke("CaptureInternal", eventName, properties);
+        }
+
+        public async Task Identify(
+            string distinctId,
+            Dictionary<string, object> properties,
+            Dictionary<string, object> setOnce
+        )
+        {
+            var task = (Task)Invoke("IdentifyInternalAsync", distinctId, properties, setOnce);
+            await task;
+        }
+
+        public void Group(string groupType, string groupKey, Dictionary<string, object> properties)
+        {
+            Invoke("GroupInternal", groupType, groupKey, properties);
+        }
+
+        public void TrackFeatureFlag()
+        {
+            _featureFlagManager.TrackFlagCalled("checkout-layout", "test");
+        }
+
+        public void CaptureException(Exception exception, Dictionary<string, object> properties)
+        {
+            _exceptionManager.CaptureException(exception, properties);
+        }
+
+        public PostHogEvent CaptureOneForRequest()
+        {
+            Capture(
+                "wire event",
+                new Dictionary<string, object>
+                {
+                    ["nested"] = new Dictionary<string, object> { ["ok"] = true },
+                }
+            );
+            var json = _storage.LoadEvent(_storage.GetEventIds().Last());
+            var dict = JsonSerializer.DeserializeDictionary(json);
+            return new PostHogEvent
+            {
+                Uuid = dict["uuid"].ToString(),
+                Event = dict["event"].ToString(),
+                DistinctId = dict["distinct_id"].ToString(),
+                Timestamp = dict["timestamp"].ToString(),
+                Properties = (Dictionary<string, object>)dict["properties"],
+            };
+        }
+
+        object Invoke(string methodName, params object[] arguments)
+        {
+            var method = typeof(PostHogSDK).GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+            Assert.NotNull(method);
+            return method.Invoke(_sdk, arguments);
+        }
+
+        static void SetField(PostHogSDK sdk, string name, object value)
+        {
+            var field = typeof(PostHogSDK).GetField(
+                name,
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+            Assert.NotNull(field);
+            field.SetValue(sdk, value);
+        }
+    }
+
+    sealed class InMemoryStorageProvider : IStorageProvider
+    {
+        readonly Dictionary<string, string> _events = new();
+        readonly List<string> _eventIds = new();
+        readonly Dictionary<string, string> _state = new();
+
+        public void Initialize(string basePath) { }
+
+        public void SaveEvent(string id, string jsonData)
+        {
+            if (!_events.ContainsKey(id))
+            {
+                _eventIds.Add(id);
+            }
+            _events[id] = jsonData;
+        }
+
+        public string LoadEvent(string id) => _events.GetValueOrDefault(id);
+
+        public void DeleteEvent(string id)
+        {
+            _events.Remove(id);
+            _eventIds.Remove(id);
+        }
+
+        public IReadOnlyList<string> GetEventIds() => _eventIds;
+
+        public int GetEventCount() => _events.Count;
+
+        public void Clear()
+        {
+            _events.Clear();
+            _eventIds.Clear();
+        }
+
+        public void SaveState(string key, string jsonData) => _state[key] = jsonData;
+
+        public string LoadState(string key) => _state.GetValueOrDefault(key);
+
+        public void DeleteState(string key) => _state.Remove(key);
+    }
+}

--- a/tests/PostHog.Unity.Tests/GoldenSnapshot.cs
+++ b/tests/PostHog.Unity.Tests/GoldenSnapshot.cs
@@ -1,0 +1,77 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace PostHogUnity.Tests
+{
+    static class GoldenSnapshot
+    {
+        public static void Match(string fileName, JsonNode actual)
+        {
+            var snapshotPath = FindSnapshotPath(fileName);
+            var canonicalActual =
+                Canonicalize(actual)
+                    .ToJsonString(
+                        new JsonSerializerOptions
+                        {
+                            WriteIndented = true,
+                            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                        }
+                    ) + Environment.NewLine;
+
+            if (Environment.GetEnvironmentVariable("UPDATE_SNAPSHOTS") == "1")
+            {
+                File.WriteAllText(snapshotPath, canonicalActual);
+                return;
+            }
+
+            Assert.True(
+                File.Exists(snapshotPath),
+                $"Snapshot not found: {snapshotPath}. Run with UPDATE_SNAPSHOTS=1 to create it."
+            );
+            Assert.Equal(File.ReadAllText(snapshotPath), canonicalActual);
+        }
+
+        static string FindSnapshotPath(string fileName)
+        {
+            var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
+            while (directory != null)
+            {
+                var candidate = Path.Combine(
+                    directory.FullName,
+                    "tests",
+                    "PostHog.Unity.Tests",
+                    "Snapshots",
+                    fileName
+                );
+                if (Directory.Exists(Path.GetDirectoryName(candidate)))
+                {
+                    return candidate;
+                }
+                directory = directory.Parent;
+            }
+
+            return Path.Combine(AppContext.BaseDirectory, "Snapshots", fileName);
+        }
+
+        static JsonNode Canonicalize(JsonNode node)
+        {
+            return node switch
+            {
+                JsonObject obj => new JsonObject(
+                    obj.OrderBy(property => property.Key, StringComparer.Ordinal)
+                        .Select(property =>
+                            KeyValuePair.Create(
+                                property.Key,
+                                property.Value == null ? null : Canonicalize(property.Value)
+                            )
+                        )
+                ),
+                JsonArray array => new JsonArray(
+                    array.Select(item => item == null ? null : Canonicalize(item)).ToArray()
+                ),
+                _ => node.DeepClone(),
+            };
+        }
+    }
+}

--- a/tests/PostHog.Unity.Tests/PostHog.Unity.Tests.csproj
+++ b/tests/PostHog.Unity.Tests/PostHog.Unity.Tests.csproj
@@ -28,6 +28,10 @@
         <PackageReference Include="Unity3D.SDK" Version="2021.1.14.1" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="Snapshots/**/*.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
     <PropertyGroup>
         <!-- Suppress framework compatibility warning for Unity stubs -->
         <NoWarn>NU1701</NoWarn>

--- a/tests/PostHog.Unity.Tests/RequestShapeSnapshotTests.cs
+++ b/tests/PostHog.Unity.Tests/RequestShapeSnapshotTests.cs
@@ -1,0 +1,182 @@
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using System.Text.Json.Nodes;
+using PostHogUnity.SessionReplay;
+
+namespace PostHogUnity.Tests
+{
+    public class RequestShapeSnapshotTests
+    {
+        [Fact]
+        public void RequestsMatchGoldenMethodPathHeadersAndDecodedBodies()
+        {
+            var requests = new JsonObject
+            {
+                ["batch"] = CreateBatchRequestSnapshot(),
+                ["feature_flags"] = CreateFeatureFlagsRequestSnapshot(),
+                ["session_replay"] = CreateReplayRequestSnapshot(),
+            };
+
+            GoldenSnapshot.Match("request-shapes.snap.json", requests);
+        }
+
+        static JsonObject CreateBatchRequestSnapshot()
+        {
+            var config = new PostHogConfig
+            {
+                ApiKey = "phc_snapshot_key",
+                Host = "https://example.com/ingest/",
+            };
+            var evt = new SdkPipelineHarness().CaptureOneForRequest();
+            var payload = new BatchPayload("phc_snapshot_key", new List<PostHogEvent> { evt });
+            Assert.True(DateTimeOffset.TryParse(payload.SentAt, out _));
+            payload.SentAt = "<sent-at>";
+
+            var request = new NetworkClient(config).CreateBatchRequestData(payload);
+            var snapshot = SnapshotRequest(
+                request,
+                request.Body,
+                "Content-Type",
+                "Accept",
+                "User-Agent"
+            );
+            var body = Assert.IsType<JsonObject>(snapshot["body"]);
+            var batch = Assert.IsType<JsonArray>(body["batch"]);
+            EventShapeSnapshotTests.NormalizeEnrichedEvent(Assert.IsType<JsonObject>(batch[0]));
+            return snapshot;
+        }
+
+        static JsonObject CreateFeatureFlagsRequestSnapshot()
+        {
+            var request = NetworkClient.CreateFlagsRequestData(
+                "phc_snapshot_key",
+                "https://example.com/ingest/",
+                "user-123",
+                "anonymous-id",
+                new Dictionary<string, string> { ["company"] = "posthog" },
+                new Dictionary<string, object>
+                {
+                    ["email"] = "person@example.com",
+                    ["$app_version"] = "1.2.3",
+                },
+                new Dictionary<string, Dictionary<string, object>>
+                {
+                    ["company"] = new Dictionary<string, object>
+                    {
+                        ["industry"] = "software",
+                        ["employees"] = 100,
+                    },
+                }
+            );
+
+            return SnapshotRequest(request, request.Body, "Content-Type", "Accept", "User-Agent");
+        }
+
+        static JsonObject CreateReplayRequestSnapshot()
+        {
+            var queue = new ReplayQueue(
+                new PostHogSessionReplayConfig { FlushAt = 10 },
+                "phc_snapshot_key",
+                "https://example.com/ingest/",
+                () => "user-123",
+                () => "session-123"
+            );
+            queue.Enqueue(
+                new List<RREvent>
+                {
+                    RREvent.CreateMeta(1280, 720, "Checkout", 1700000000000),
+                    RREvent.CreateFullSnapshot(
+                        RRWireframe.CreateScreenshot(
+                            640,
+                            360,
+                            "data:image/jpeg;base64,c25hcHNob3Q="
+                        ),
+                        1700000000100
+                    ),
+                }
+            );
+
+            var field = typeof(ReplayQueue).GetField(
+                "_queue",
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+            Assert.NotNull(field);
+            var events = Assert.IsType<List<SnapshotEvent>>(field.GetValue(queue));
+            var replayEvent = Assert.Single(events);
+            Assert.True(Guid.TryParse(replayEvent.Uuid, out _));
+            Assert.Equal('7', replayEvent.Uuid.Split('-')[2][0]);
+            Assert.True(DateTimeOffset.TryParse(replayEvent.Timestamp, out _));
+            replayEvent.Uuid = "<uuid-v7>";
+            replayEvent.Timestamp = "<timestamp>";
+
+            var request = queue.CreateBatchRequestData(events);
+            Assert.Equal("gzip", request.Headers["Content-Encoding"]);
+            var decodedBody = Decompress(request.Body);
+            var snapshot = SnapshotRequest(
+                request,
+                decodedBody,
+                "Content-Type",
+                "Accept",
+                "Content-Encoding"
+            );
+            var body = Assert.IsType<JsonArray>(snapshot["body"]);
+            var normalizedReplayEvent = Assert.IsType<JsonObject>(Assert.Single(body));
+            var properties = Assert.IsType<JsonObject>(normalizedReplayEvent["properties"]);
+            EventShapeSnapshotTests.NormalizeSdkVersion(properties);
+            return snapshot;
+        }
+
+        static JsonObject SnapshotRequest(
+            HttpRequestData request,
+            byte[] decodedBody,
+            params string[] headerNames
+        )
+        {
+            var uri = new Uri(request.Url);
+            foreach (var headerName in headerNames)
+            {
+                Assert.True(request.Headers.TryGetValue(headerName, out var value));
+                Assert.False(string.IsNullOrEmpty(value), $"Missing {headerName} header");
+            }
+            var headers = new JsonObject();
+            foreach (var header in request.Headers)
+            {
+                var value = header.Value;
+                if (header.Key == "User-Agent")
+                {
+                    const string prefix = "posthog-unity/";
+                    Assert.StartsWith(prefix, value);
+                    Assert.True(value.Length > prefix.Length);
+                    value = "posthog-unity/<sdk-version>";
+                }
+                headers[header.Key] = value;
+            }
+
+            Assert.Equal("POST", request.Method);
+            Assert.NotNull(request.Body);
+            Assert.True(request.TimeoutSeconds > 0);
+
+            return new JsonObject
+            {
+                ["method"] = request.Method,
+                ["scheme"] = uri.Scheme,
+                ["host"] = uri.Authority,
+                ["path"] = uri.AbsolutePath,
+                ["query"] = uri.Query,
+                ["headers"] = headers,
+                ["timeout_seconds"] = request.TimeoutSeconds,
+                ["body"] = JsonNode.Parse(Encoding.UTF8.GetString(decodedBody)),
+            };
+        }
+
+        static byte[] Decompress(byte[] payload)
+        {
+            using var input = new MemoryStream(payload);
+            using var gzip = new GZipStream(input, CompressionMode.Decompress);
+            using var output = new MemoryStream();
+            gzip.CopyTo(output);
+            return output.ToArray();
+        }
+    }
+}

--- a/tests/PostHog.Unity.Tests/Snapshots/event-shapes.snap.json
+++ b/tests/PostHog.Unity.Tests/Snapshots/event-shapes.snap.json
@@ -1,0 +1,189 @@
+[
+  {
+    "distinct_id": "anonymous-id",
+    "event": "checkout completed",
+    "properties": {
+      "$app_build": "snapshot-build",
+      "$app_name": "Snapshot Game",
+      "$app_version": "1.2.3",
+      "$device_manufacturer": "Snapshot Device",
+      "$device_model": "Snapshot Device",
+      "$device_type": "Desktop",
+      "$lib": "posthog-unity",
+      "$lib_version": "<sdk-version>",
+      "$os": "SnapshotOS",
+      "$os_version": "1.0",
+      "$process_person_profile": false,
+      "$screen_height": 720,
+      "$screen_width": 1280,
+      "$session_id": "<session-id>",
+      "amount": 42.5,
+      "currency": "USD",
+      "items": [
+        "hedgehog plush",
+        "sticker"
+      ],
+      "plan": "enterprise",
+      "source": "snapshot-test"
+    },
+    "timestamp": "<timestamp>",
+    "uuid": "<uuid-v7>"
+  },
+  {
+    "distinct_id": "user-123",
+    "event": "$identify",
+    "properties": {
+      "$anon_distinct_id": "anonymous-id",
+      "$app_build": "snapshot-build",
+      "$app_name": "Snapshot Game",
+      "$app_version": "1.2.3",
+      "$device_manufacturer": "Snapshot Device",
+      "$device_model": "Snapshot Device",
+      "$device_type": "Desktop",
+      "$lib": "posthog-unity",
+      "$lib_version": "<sdk-version>",
+      "$os": "SnapshotOS",
+      "$os_version": "1.0",
+      "$screen_height": 720,
+      "$screen_width": 1280,
+      "$session_id": "<session-id>",
+      "$set": {
+        "email": "person@example.com",
+        "name": "Hedge Hog"
+      },
+      "$set_once": {
+        "created_via": "unity"
+      },
+      "plan": "starter",
+      "source": "snapshot-test"
+    },
+    "timestamp": "<timestamp>",
+    "uuid": "<uuid-v7>"
+  },
+  {
+    "distinct_id": "user-123",
+    "event": "$groupidentify",
+    "properties": {
+      "$app_build": "snapshot-build",
+      "$app_name": "Snapshot Game",
+      "$app_version": "1.2.3",
+      "$device_manufacturer": "Snapshot Device",
+      "$device_model": "Snapshot Device",
+      "$device_type": "Desktop",
+      "$group_key": "posthog",
+      "$group_set": {
+        "employees": 100,
+        "name": "PostHog"
+      },
+      "$group_type": "company",
+      "$groups": {
+        "company": "posthog"
+      },
+      "$lib": "posthog-unity",
+      "$lib_version": "<sdk-version>",
+      "$os": "SnapshotOS",
+      "$os_version": "1.0",
+      "$screen_height": 720,
+      "$screen_width": 1280,
+      "$session_id": "<session-id>",
+      "plan": "starter",
+      "source": "snapshot-test"
+    },
+    "timestamp": "<timestamp>",
+    "uuid": "<uuid-v7>"
+  },
+  {
+    "distinct_id": "user-123",
+    "event": "$feature_flag_called",
+    "properties": {
+      "$app_build": "snapshot-build",
+      "$app_name": "Snapshot Game",
+      "$app_version": "1.2.3",
+      "$device_manufacturer": "Snapshot Device",
+      "$device_model": "Snapshot Device",
+      "$device_type": "Desktop",
+      "$feature_flag": "checkout-layout",
+      "$feature_flag_evaluated_at": 1700000000,
+      "$feature_flag_id": 17,
+      "$feature_flag_reason": "Matched snapshot cohort",
+      "$feature_flag_request_id": "request-123",
+      "$feature_flag_response": "test",
+      "$feature_flag_version": 3,
+      "$groups": {
+        "company": "posthog"
+      },
+      "$lib": "posthog-unity",
+      "$lib_version": "<sdk-version>",
+      "$os": "SnapshotOS",
+      "$os_version": "1.0",
+      "$screen_height": 720,
+      "$screen_width": 1280,
+      "$session_id": "<session-id>",
+      "plan": "starter",
+      "source": "snapshot-test"
+    },
+    "timestamp": "<timestamp>",
+    "uuid": "<uuid-v7>"
+  },
+  {
+    "distinct_id": "user-123",
+    "event": "$exception",
+    "properties": {
+      "$app_build": "snapshot-build",
+      "$app_name": "Snapshot Game",
+      "$app_version": "1.2.3",
+      "$device_manufacturer": "Snapshot Device",
+      "$device_model": "Snapshot Device",
+      "$device_type": "Desktop",
+      "$exception_handled": true,
+      "$exception_level": "error",
+      "$exception_list": [
+        {
+          "mechanism": {
+            "handled": true,
+            "source": "unity",
+            "synthetic": false,
+            "type": "generic"
+          },
+          "stacktrace": {
+            "frames": [
+              {
+                "abs_path": "<abs_path>",
+                "colno": "<colno>",
+                "filename": "EventShapeSnapshotTests.cs",
+                "function": "CreateSnapshotException",
+                "lang": "csharp",
+                "lineno": "<lineno>",
+                "module": "PostHogUnity.Tests.EventShapeSnapshotTests",
+                "platform": "custom"
+              }
+            ],
+            "type": "raw"
+          },
+          "type": "System.InvalidOperationException",
+          "value": "snapshot boom"
+        }
+      ],
+      "$exception_message": "snapshot boom",
+      "$exception_personURL": "https://example.com/ingest/project/phc_snapshot_key/person/user-123",
+      "$exception_source": "unity_sdk",
+      "$exception_type": "System.InvalidOperationException",
+      "$groups": {
+        "company": "posthog"
+      },
+      "$lib": "posthog-unity",
+      "$lib_version": "<sdk-version>",
+      "$os": "SnapshotOS",
+      "$os_version": "1.0",
+      "$screen_height": 720,
+      "$screen_width": 1280,
+      "$session_id": "<session-id>",
+      "$unity_version": "2021.snapshot",
+      "plan": "starter",
+      "scene": "Checkout",
+      "source": "snapshot-test"
+    },
+    "timestamp": "<timestamp>",
+    "uuid": "<uuid-v7>"
+  }
+]

--- a/tests/PostHog.Unity.Tests/Snapshots/request-shapes.snap.json
+++ b/tests/PostHog.Unity.Tests/Snapshots/request-shapes.snap.json
@@ -1,0 +1,140 @@
+{
+  "batch": {
+    "body": {
+      "api_key": "phc_snapshot_key",
+      "batch": [
+        {
+          "distinct_id": "anonymous-id",
+          "event": "wire event",
+          "properties": {
+            "$app_build": "snapshot-build",
+            "$app_name": "Snapshot Game",
+            "$app_version": "1.2.3",
+            "$device_manufacturer": "Snapshot Device",
+            "$device_model": "Snapshot Device",
+            "$device_type": "Desktop",
+            "$lib": "posthog-unity",
+            "$lib_version": "<sdk-version>",
+            "$os": "SnapshotOS",
+            "$os_version": "1.0",
+            "$process_person_profile": false,
+            "$screen_height": 720,
+            "$screen_width": 1280,
+            "$session_id": "<session-id>",
+            "nested": {
+              "ok": true
+            },
+            "plan": "starter",
+            "source": "snapshot-test"
+          },
+          "timestamp": "<timestamp>",
+          "uuid": "<uuid-v7>"
+        }
+      ],
+      "sent_at": "<sent-at>"
+    },
+    "headers": {
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": "posthog-unity/<sdk-version>"
+    },
+    "host": "example.com",
+    "method": "POST",
+    "path": "/ingest/batch",
+    "query": "",
+    "scheme": "https",
+    "timeout_seconds": 10
+  },
+  "feature_flags": {
+    "body": {
+      "$anon_distinct_id": "anonymous-id",
+      "$groups": {
+        "company": "posthog"
+      },
+      "api_key": "phc_snapshot_key",
+      "distinct_id": "user-123",
+      "group_properties": {
+        "company": {
+          "employees": 100,
+          "industry": "software"
+        }
+      },
+      "person_properties": {
+        "$app_version": "1.2.3",
+        "email": "person@example.com"
+      }
+    },
+    "headers": {
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": "posthog-unity/<sdk-version>"
+    },
+    "host": "example.com",
+    "method": "POST",
+    "path": "/ingest/flags/",
+    "query": "?v=2",
+    "scheme": "https",
+    "timeout_seconds": 10
+  },
+  "session_replay": {
+    "body": [
+      {
+        "api_key": "phc_snapshot_key",
+        "distinct_id": "user-123",
+        "event": "$snapshot",
+        "properties": {
+          "$lib": "posthog-unity",
+          "$lib_version": "<sdk-version>",
+          "$session_id": "session-123",
+          "$snapshot_data": [
+            {
+              "data": {
+                "height": 720,
+                "href": "Checkout",
+                "width": 1280
+              },
+              "timestamp": 1700000000000,
+              "type": 4
+            },
+            {
+              "data": {
+                "initialOffset": {
+                  "left": 0,
+                  "top": 0
+                },
+                "wireframes": [
+                  {
+                    "base64": "data:image/jpeg;base64,c25hcHNob3Q=",
+                    "height": 360,
+                    "id": 1,
+                    "type": "screenshot",
+                    "width": 640,
+                    "x": 0,
+                    "y": 0
+                  }
+                ]
+              },
+              "timestamp": 1700000000100,
+              "type": 2
+            }
+          ],
+          "$snapshot_source": "mobile",
+          "$window_id": "session-123"
+        },
+        "timestamp": "<timestamp>",
+        "uuid": "<uuid-v7>"
+      }
+    ],
+    "headers": {
+      "Accept": "application/json",
+      "Content-Encoding": "gzip",
+      "Content-Type": "application/json"
+    },
+    "host": "example.com",
+    "method": "POST",
+    "path": "/ingest/s/",
+    "query": "",
+    "scheme": "https",
+    "timeout_seconds": 30
+  }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Material changes to final enriched events or wire request parameters should require an explicit golden update. This brings the deterministic coverage introduced for the browser in [d0933e1](https://github.com/PostHog/posthog-js/commit/d0933e1bcb600957b82e37d72dab895ceed16e27) to the Unity SDK.

The new tests snapshot enriched event shapes plus batch, flags, and replay request descriptors. Small internal seams make runtime metadata and pre-adapter request data deterministic without changing production behavior; runtime information is immutable. Recording requires `UPDATE_SNAPSHOTS=1`.

## :green_heart: How did you test it?

- `UPDATE_SNAPSHOTS=1 dotnet test tests/PostHog.Unity.Tests/PostHog.Unity.Tests.csproj --filter 'FullyQualifiedName~SnapshotTests'`
- `dotnet test tests/PostHog.Unity.Tests/PostHog.Unity.Tests.csproj` — 453 passed, 2 skipped
- `./bin/fmt --check`
- Parsed all JSON fixtures

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and built-in reviewer subagents in a local session. Request descriptors are captured before the Unity adapter because the .NET Unity stubs cannot safely construct live `UnityWebRequest` instances.
