### PR TITLE
chore: expand Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    reviewers:
-      - "PostHog/team-client-libraries"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,25 @@
 version: 2
 updates:
+  - package-ecosystem: "nuget"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      nuget-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      release-tooling:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     cooldown:
       default-days: 7


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot was only configured for GitHub Actions. The repository also has NuGet manifests at the root and in nested project directories, plus npm tooling at the root for releases.

This change adds weekly NuGet and npm updates with a seven-day cooldown. NuGet updates are grouped as `nuget-dependencies`, npm updates are grouped as `release-tooling`, and the existing GitHub Actions updates remain grouped as `github-actions`. Each group uses a catch-all dependency pattern. The explicit Dependabot reviewer setting remains removed because the catch-all CODEOWNERS rule assigns the client libraries team.

## :green_heart: How did you test it?

- Parsed the YAML and asserted the exact ecosystem order, root directories, weekly schedules, seven-day cooldowns, group names, and catch-all patterns.
- Confirmed the root and nested NuGet manifests, root npm manifests, and catch-all CODEOWNERS rule.
- Ran `./bin/fmt --check` and `git diff --check`.
- Ran autoreview against `origin/main` for commit `567bfa41fb677eb1557ca9564f91f5b8f6c73a80`; it reported no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi's worker agent made the requested Dependabot configuration change. The Pi autoreview tool reviewed the final branch diff before it was pushed.
