### PR TITLE
test: normalize generated timestamps to UTC

### DIFF
--- a/.changeset/calm-clocks-align.md
+++ b/.changeset/calm-clocks-align.md
@@ -1,5 +1,0 @@
----
-'com.posthog.unity': patch
----
-
-Normalize SDK-generated event, batch, and session replay timestamps to UTC.

--- a/.changeset/calm-clocks-align.md
+++ b/.changeset/calm-clocks-align.md
@@ -1,0 +1,5 @@
+---
+'com.posthog.unity': patch
+---
+
+Normalize SDK-generated event, batch, and session replay timestamps to UTC.

--- a/com.posthog.unity/Runtime/Models/BatchPayload.cs
+++ b/com.posthog.unity/Runtime/Models/BatchPayload.cs
@@ -20,7 +20,7 @@ namespace PostHogUnity
         public List<PostHogEvent> Batch { get; set; }
 
         /// <summary>
-        /// ISO 8601 timestamp when the batch was sent.
+        /// ISO 8601 timestamp when the batch was sent. SDK-generated values are UTC.
         /// </summary>
         public string SentAt { get; set; }
 
@@ -30,7 +30,7 @@ namespace PostHogUnity
         public BatchPayload()
         {
             Batch = new List<PostHogEvent>();
-            SentAt = DateTime.UtcNow.ToString("o");
+            SentAt = UtcTimestamp.Now();
         }
 
         /// <summary>

--- a/com.posthog.unity/Runtime/Models/PostHogEvent.cs
+++ b/com.posthog.unity/Runtime/Models/PostHogEvent.cs
@@ -25,7 +25,7 @@ namespace PostHogUnity
         public string DistinctId { get; set; }
 
         /// <summary>
-        /// ISO 8601 timestamp when the event occurred.
+        /// ISO 8601 timestamp when the event occurred. SDK-generated values are UTC.
         /// </summary>
         public string Timestamp { get; set; }
 
@@ -40,7 +40,7 @@ namespace PostHogUnity
         public PostHogEvent()
         {
             Uuid = UuidV7.Generate();
-            Timestamp = DateTime.UtcNow.ToString("o");
+            Timestamp = UtcTimestamp.Now();
             Properties = new Dictionary<string, object>();
         }
 

--- a/com.posthog.unity/Runtime/SessionReplay/ReplayQueue.cs
+++ b/com.posthog.unity/Runtime/SessionReplay/ReplayQueue.cs
@@ -89,7 +89,7 @@ namespace PostHogUnity.SessionReplay
             var evt = new SnapshotEvent
             {
                 Uuid = UuidV7.Generate(),
-                Timestamp = DateTime.UtcNow.ToString("o"),
+                Timestamp = UtcTimestamp.Now(),
                 DistinctId = _getDistinctId(),
                 SessionId = sessionId,
                 SnapshotData = snapshotData,

--- a/com.posthog.unity/Runtime/Utilities/UtcTimestamp.cs
+++ b/com.posthog.unity/Runtime/Utilities/UtcTimestamp.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Globalization;
+
+namespace PostHogUnity
+{
+    static class UtcTimestamp
+    {
+        public static string Now() => Format(DateTimeOffset.UtcNow);
+
+        internal static string Format(DateTimeOffset timestamp) =>
+            timestamp.UtcDateTime.ToString(
+                "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'",
+                CultureInfo.InvariantCulture
+            );
+    }
+}

--- a/com.posthog.unity/Runtime/Utilities/UtcTimestamp.cs.meta
+++ b/com.posthog.unity/Runtime/Utilities/UtcTimestamp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bac9103734249889bac774786bb3f69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/tests/PostHog.Unity.Tests/JsonSerializerTests.cs
+++ b/tests/PostHog.Unity.Tests/JsonSerializerTests.cs
@@ -146,6 +146,27 @@ namespace PostHogUnity.Tests
             }
         }
 
+        public class TheUtcTimestampFormatter
+        {
+            [Fact]
+            public void WithNonUtcOffset_ConvertsEquivalentInstantToExactUtcWireValue()
+            {
+                var timestamp = new DateTimeOffset(
+                    2025,
+                    1,
+                    15,
+                    10,
+                    30,
+                    45,
+                    TimeSpan.FromHours(5.5)
+                );
+
+                var result = UtcTimestamp.Format(timestamp);
+
+                Assert.Equal("2025-01-15T05:00:45.0000000Z", result);
+            }
+        }
+
         public class TheSerializeEventMethod
         {
             [Fact]
@@ -162,7 +183,8 @@ namespace PostHogUnity.Tests
                 Assert.Contains("\"event\":\"test_event\"", result);
                 Assert.Contains("\"distinct_id\":\"user123\"", result);
                 Assert.Contains("\"uuid\":", result);
-                Assert.Contains("\"timestamp\":", result);
+                Assert.Contains($"\"timestamp\":\"{evt.Timestamp}\"", result);
+                Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$", evt.Timestamp);
                 Assert.Contains("\"properties\":{}", result);
             }
 
@@ -193,7 +215,8 @@ namespace PostHogUnity.Tests
                 var result = JsonSerializer.SerializeBatch(payload);
 
                 Assert.Contains("\"api_key\":\"test_api_key\"", result);
-                Assert.Contains("\"sent_at\":", result);
+                Assert.Contains($"\"sent_at\":\"{payload.SentAt}\"", result);
+                Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$", payload.SentAt);
                 Assert.Contains("\"batch\":[]", result);
             }
 

--- a/tests/PostHog.Unity.Tests/PostHogEventTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogEventTests.cs
@@ -24,9 +24,16 @@ namespace PostHogUnity.Tests
                 var after = DateTime.UtcNow;
 
                 Assert.NotNull(evt.Timestamp);
-                Assert.True(DateTime.TryParse(evt.Timestamp, out var timestamp));
-                // Parse returns local time, convert to UTC for comparison
-                timestamp = timestamp.ToUniversalTime();
+                Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$", evt.Timestamp);
+                Assert.True(
+                    DateTime.TryParse(
+                        evt.Timestamp,
+                        null,
+                        System.Globalization.DateTimeStyles.RoundtripKind,
+                        out var timestamp
+                    )
+                );
+                Assert.Equal(DateTimeKind.Utc, timestamp.Kind);
                 Assert.True(
                     timestamp >= before.AddSeconds(-1),
                     $"Timestamp {timestamp} should be >= {before.AddSeconds(-1)}"
@@ -80,7 +87,7 @@ namespace PostHogUnity.Tests
                 var evt = new PostHogEvent("test_event", "user123");
 
                 Assert.NotNull(evt.Timestamp);
-                Assert.True(DateTime.TryParse(evt.Timestamp, out _));
+                Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$", evt.Timestamp);
             }
 
             [Fact]

--- a/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
+++ b/tests/PostHog.Unity.Tests/PostHogSDKTests.cs
@@ -174,6 +174,29 @@ namespace PostHogUnity.Tests
                 Assert.False(processed.Properties.ContainsKey("secret"));
             }
 
+            [Fact]
+            public void PreservesCallerControlledTimestampMutation()
+            {
+                const string callerTimestamp = "not-an-sdk-timestamp";
+                var config = new PostHogConfig
+                {
+                    ApiKey = "test-api-key",
+                    BeforeSend = evt =>
+                    {
+                        evt.Timestamp = callerTimestamp;
+                        return evt;
+                    },
+                };
+                var sdk = CreateSdk(config);
+
+                var processed = RunBeforeSend(
+                    sdk,
+                    new PostHogEvent("before-send-event", "distinct-id")
+                );
+
+                Assert.Equal(callerTimestamp, processed.Timestamp);
+            }
+
             [Theory]
             [MemberData(nameof(DropCallbacks))]
             public void CanDropEventBeforeItIsQueued(Func<PostHogEvent, PostHogEvent> beforeSend)

--- a/tests/PostHog.Unity.Tests/ReplayQueueTests.cs
+++ b/tests/PostHog.Unity.Tests/ReplayQueueTests.cs
@@ -26,10 +26,7 @@ namespace PostHogUnity.Tests
             var events = Assert.IsType<List<SnapshotEvent>>(queueField.GetValue(queue));
             var envelope = Assert.Single(events);
 
-            Assert.Matches(
-                @"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$",
-                envelope.Timestamp
-            );
+            Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$", envelope.Timestamp);
             Assert.Equal(123L, Assert.Single(envelope.SnapshotData).Timestamp);
         }
 

--- a/tests/PostHog.Unity.Tests/ReplayQueueTests.cs
+++ b/tests/PostHog.Unity.Tests/ReplayQueueTests.cs
@@ -23,16 +23,14 @@ namespace PostHogUnity.Tests
                 BindingFlags.Instance | BindingFlags.NonPublic
             );
             Assert.NotNull(queueField);
-            var events = Assert.IsAssignableFrom<System.Collections.IList>(
-                queueField.GetValue(queue)
-            );
-            var envelope = Assert.Single(events.Cast<object>());
-            var timestampProperty = envelope.GetType().GetProperty("Timestamp");
-            Assert.NotNull(timestampProperty);
-            var timestamp = Assert.IsType<string>(timestampProperty.GetValue(envelope));
+            var events = Assert.IsType<List<SnapshotEvent>>(queueField.GetValue(queue));
+            var envelope = Assert.Single(events);
 
-            Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$", timestamp);
-            Assert.Equal(123L, RREvent.CreateMeta(100, 200, "Home", 123L).Timestamp);
+            Assert.Matches(
+                @"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$",
+                envelope.Timestamp
+            );
+            Assert.Equal(123L, Assert.Single(envelope.SnapshotData).Timestamp);
         }
 
         [Fact]

--- a/tests/PostHog.Unity.Tests/ReplayQueueTests.cs
+++ b/tests/PostHog.Unity.Tests/ReplayQueueTests.cs
@@ -1,9 +1,40 @@
+using System.Reflection;
 using PostHogUnity.SessionReplay;
 
 namespace PostHogUnity.Tests
 {
     public class ReplayQueueTests
     {
+        [Fact]
+        public void EnqueueCreatesReplayEnvelopeWithUtcTimestamp()
+        {
+            var queue = new ReplayQueue(
+                new PostHogSessionReplayConfig(),
+                "test-api-key",
+                "https://example.com",
+                () => "distinct-id",
+                () => "session-id"
+            );
+
+            queue.Enqueue(new List<RREvent> { RREvent.CreateMeta(100, 200, "Home", 123L) });
+
+            var queueField = typeof(ReplayQueue).GetField(
+                "_queue",
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+            Assert.NotNull(queueField);
+            var events = Assert.IsAssignableFrom<System.Collections.IList>(
+                queueField.GetValue(queue)
+            );
+            var envelope = Assert.Single(events.Cast<object>());
+            var timestampProperty = envelope.GetType().GetProperty("Timestamp");
+            Assert.NotNull(timestampProperty);
+            var timestamp = Assert.IsType<string>(timestampProperty.GetValue(envelope));
+
+            Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$", timestamp);
+            Assert.Equal(123L, RREvent.CreateMeta(100, 200, "Home", 123L).Timestamp);
+        }
+
         [Fact]
         public void PreparePayloadCompressesSmallPayloads()
         {


### PR DESCRIPTION
## :bulb: Motivation and Context

SDK-generated timestamps should have one stable UTC wire format across Unity runtimes. Event timestamps, batch `sent_at` values, and session replay envelope timestamps now use an invariant formatter that converts the instant to UTC and emits seven fractional-second digits followed by `Z`.

Caller-controlled event timestamps remain unchanged. A `BeforeSend` callback can still replace an event timestamp with any caller-provided value.

The regression tests cover conversion from a `+05:30` offset to the exact equivalent UTC value, UTC parsing and wire formatting for generated event and batch timestamps, the replay envelope timestamp without changing the rrweb millisecond timestamp, and preservation of a timestamp set in `BeforeSend`.

## :green_heart: How did you test it?

- `bin/test` - 454 passed and 2 WebGL integration tests skipped
- `bin/fmt --check`
- `bin/build`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Prepared with [Pi](https://pi.dev/) using the worker agent and the autoreview skill. The implementation keeps caller-provided timestamps intact and only normalizes timestamps generated by the SDK. Autoreview found no actionable findings.
